### PR TITLE
thcrap_wrapper: Set current directory using...

### DIFF
--- a/thcrap_wrapper/src/thcrap_wrapper.c
+++ b/thcrap_wrapper/src/thcrap_wrapper.c
@@ -1,4 +1,5 @@
 #include <windows.h>
+#include <shlwapi.h>
 
 // A quick implementation of a few CRT functions because we don't link with the CRT.
 size_t my_wcslen(const wchar_t *str)
@@ -105,6 +106,14 @@ int main()
 	else {
 		commandLineUsed = rcCommandLine;
 	}
+
+	if (rcCurrentDirectory == NULL) {
+		rcCurrentDirectory = HeapAlloc(GetProcessHeap(), 1, MAX_PATH);
+		GetModuleFileNameW(NULL, rcCurrentDirectory, MAX_PATH);
+		PathRemoveFileSpecW(rcCurrentDirectory);
+	}
+
+	SetCurrentDirectoryW(rcCurrentDirectory);
 
     for (unsigned int i = 0; i < sizeof(si); i++) ((BYTE*)&si)[i] = 0;
     si.cb = sizeof(si);

--- a/thcrap_wrapper/thcrap_wrapper.props
+++ b/thcrap_wrapper/thcrap_wrapper.props
@@ -22,6 +22,7 @@
       <SubSystem>Windows</SubSystem>
 	  <!-- Note: this removes the dependency on the CRT for the release build, but not for the debug one. -->
       <EntryPointSymbol>main</EntryPointSymbol>
+	  <AdditionalDependencies>shlwapi.lib;%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
   </ItemDefinitionGroup>
   <ItemGroup>


### PR DESCRIPTION
path provided by GetModuleFileName if rcCurrentDirectory is not set.
This will make it possible to run a command like
`thcrap\thcrap_loader.exe ...` to start thcrap

IMPORTANT NOTE: THIS WILL FAIL TO BUILD BECAUSE I DID NOT EDIT BUILD
FILES TO INCLUDE shlwapi.lib. I never worked with build systems
before :tannedcirno: but was able to test by using the Visual Studio UI
to include shlwapi.lib

(also it'd probably make sense to use NULL for the CurrentDirectory
parameter in CreateProcessW now)