### PR TITLE
Project branches, incremental updates, global config

### DIFF
--- a/thcrap/src/global.cpp
+++ b/thcrap/src/global.cpp
@@ -10,6 +10,7 @@
 #include "thcrap.h"
 
 json_t* run_cfg = NULL;
+json_t* global_cfg = NULL;
 
 const char* PROJECT_NAME(void)
 {
@@ -53,4 +54,72 @@ const json_t *runconfig_title_get(void)
 		title = json_object_get(run_cfg, "title");
 	}
 	return title ? title : (id ? id : NULL);
+}
+
+void globalconfig_init(void)
+{
+	json_decref(global_cfg);
+	global_cfg = json_load_file_report("config/config.js");
+	if (!global_cfg) {
+		global_cfg = json_object();
+	}
+}
+
+int globalconfig_dump(void)
+{
+	return json_dump_file(global_cfg, "config/config.js", JSON_INDENT(2) | JSON_SORT_KEYS);
+}
+
+BOOL globalconfig_get_boolean(char* key)
+{
+	if (!global_cfg) {
+		globalconfig_init();
+	}
+	errno = 0;
+	json_t* value_json = json_object_get(global_cfg, key);
+	if (!value_json) {
+		errno = 1;
+		return false;
+	}
+	return json_boolean_value(value_json);
+}
+
+int globalconfig_set_boolean(char* key, const BOOL value)
+{
+	if (!global_cfg) {
+		globalconfig_init();
+	}
+	errno = 0;
+	json_object_set_new(global_cfg, key, json_boolean(value));
+	return globalconfig_dump();
+}
+
+long long globalconfig_get_integer(char* key)
+{
+	if (!global_cfg) {
+		globalconfig_init();
+	}
+	errno = 0;
+	json_t* value_json = json_object_get(global_cfg, key);
+	if (!value_json) {
+		errno = 1;
+		return false;
+	}
+	return json_integer_value(value_json);
+}
+
+int globalconfig_set_integer(char* key, const long long value)
+{
+	if (!global_cfg) {
+		globalconfig_init();
+	}
+	errno = 0;
+	json_object_set_new(global_cfg, key, json_integer(value));
+	return  globalconfig_dump();
+}
+
+void globalconfig_release(void)
+{
+	json_decref(global_cfg);
+	global_cfg = json_incref(NULL);
 }

--- a/thcrap/src/global.cpp
+++ b/thcrap/src/global.cpp
@@ -70,7 +70,7 @@ int globalconfig_dump(void)
 	return json_dump_file(global_cfg, "config/config.js", JSON_INDENT(2) | JSON_SORT_KEYS);
 }
 
-BOOL globalconfig_get_boolean(char* key)
+BOOL globalconfig_get_boolean(char* key, const BOOL default_value)
 {
 	if (!global_cfg) {
 		globalconfig_init();
@@ -78,8 +78,8 @@ BOOL globalconfig_get_boolean(char* key)
 	errno = 0;
 	json_t* value_json = json_object_get(global_cfg, key);
 	if (!value_json) {
-		errno = 1;
-		return false;
+		errno = ENOENT;
+		return default_value;
 	}
 	return json_boolean_value(value_json);
 }
@@ -89,12 +89,16 @@ int globalconfig_set_boolean(char* key, const BOOL value)
 	if (!global_cfg) {
 		globalconfig_init();
 	}
-	errno = 0;
-	json_object_set_new(global_cfg, key, json_boolean(value));
+	json_t* j_value = json_boolean(value);
+	if (json_equal(j_value, json_object_get(global_cfg, key))) {
+		json_decref(j_value);
+		return 0;
+	}
+	json_object_set_new(global_cfg, key, j_value);
 	return globalconfig_dump();
 }
 
-long long globalconfig_get_integer(char* key)
+long long globalconfig_get_integer(char* key, const long long default_value)
 {
 	if (!global_cfg) {
 		globalconfig_init();
@@ -102,8 +106,8 @@ long long globalconfig_get_integer(char* key)
 	errno = 0;
 	json_t* value_json = json_object_get(global_cfg, key);
 	if (!value_json) {
-		errno = 1;
-		return false;
+		errno = ENOENT;
+		return default_value;
 	}
 	return json_integer_value(value_json);
 }
@@ -113,9 +117,13 @@ int globalconfig_set_integer(char* key, const long long value)
 	if (!global_cfg) {
 		globalconfig_init();
 	}
-	errno = 0;
-	json_object_set_new(global_cfg, key, json_integer(value));
-	return  globalconfig_dump();
+	json_t* j_value = json_integer(value);
+	if (json_equal(j_value, json_object_get(global_cfg, key))) {
+		json_decref(j_value);
+		return 0;
+	}
+	json_object_set_new(global_cfg, key, j_value);
+	return globalconfig_dump();
 }
 
 void globalconfig_release(void)

--- a/thcrap/src/global.cpp
+++ b/thcrap/src/global.cpp
@@ -31,6 +31,10 @@ const char* PROJECT_VERSION_STRING(void)
 	}
 	return ver_str;
 }
+const char* PROJECT_BRANCH(void)
+{
+	return "stable";
+}
 json_t* runconfig_get(void)
 {
 	return run_cfg;

--- a/thcrap/src/global.h
+++ b/thcrap/src/global.h
@@ -29,6 +29,21 @@ void runconfig_set(json_t *new_run_cfg);
 // • 4. NULL
 const json_t *runconfig_title_get(void);
 
+// Returns the value matching key in config converted in bool
+// If key isn't in config it returns false with errno 1
+BOOL globalconfig_get_boolean(char* key);
+// Sets the value in config and then writes the result on disk
+// It returns what json_dump_file returns
+int globalconfig_set_boolean(char* key, const BOOL value);
+// Returns the value matching key in config converted in long long
+// If key isn't in config it returns false with errno 1
+long long globalconfig_get_integer(char* key);
+// Sets the value in config and then writes the result on disk
+// It returns what json_dump_file returns
+int globalconfig_set_integer(char* key, const long long value);
+// Releases global_cfg
+void globalconfig_release(void);
+
 // Convenience macro for binary file names that differ between Debug and
 // Release builds.
 #ifdef _DEBUG

--- a/thcrap/src/global.h
+++ b/thcrap/src/global.h
@@ -30,14 +30,14 @@ void runconfig_set(json_t *new_run_cfg);
 const json_t *runconfig_title_get(void);
 
 // Returns the value matching key in config converted in bool
-// If key isn't in config it returns false with errno 1
-BOOL globalconfig_get_boolean(char* key);
+// If key isn't in config it returns default_value with errno ENOENT
+BOOL globalconfig_get_boolean(char* key, const BOOL default_value);
 // Sets the value in config and then writes the result on disk
 // It returns what json_dump_file returns
 int globalconfig_set_boolean(char* key, const BOOL value);
 // Returns the value matching key in config converted in long long
-// If key isn't in config it returns false with errno 1
-long long globalconfig_get_integer(char* key);
+// If key isn't in config it returns default_value with errno ENOENT
+long long globalconfig_get_integer(char* key, const long long default_value);
 // Sets the value in config and then writes the result on disk
 // It returns what json_dump_file returns
 int globalconfig_set_integer(char* key, const long long value);

--- a/thcrap/src/global.h
+++ b/thcrap/src/global.h
@@ -16,6 +16,7 @@ const char* PROJECT_NAME(void);
 const char* PROJECT_NAME_SHORT(void);
 DWORD PROJECT_VERSION(void);
 const char* PROJECT_VERSION_STRING(void);
+const char* PROJECT_BRANCH(void);
 
 json_t* runconfig_get(void);
 void runconfig_set(json_t *new_run_cfg);

--- a/thcrap/src/log.cpp
+++ b/thcrap/src/log.cpp
@@ -321,6 +321,7 @@ void log_init(int console)
 
 		fprintf(log_file, "%s\n", line);
 		fprintf(log_file, "%s logfile\n", PROJECT_NAME());
+		fprintf(log_file, "Branch: %s\n", PROJECT_BRANCH());
 		fprintf(log_file, "Version: %s\n", PROJECT_VERSION_STRING());
 		fprintf(log_file, "Build time: "  __DATE__ " " __TIME__ "\n");
 #if defined(BUILDER_NAME_W)

--- a/thcrap/src/thcrap.h
+++ b/thcrap/src/thcrap.h
@@ -19,7 +19,6 @@
 
 #ifdef __cplusplus
 #include <string>
-#include <regex>
 
 extern "C" {
 #endif

--- a/thcrap/src/thcrap.h
+++ b/thcrap/src/thcrap.h
@@ -19,6 +19,7 @@
 
 #ifdef __cplusplus
 #include <string>
+#include <regex>
 
 extern "C" {
 #endif

--- a/thcrap/thcrap.def
+++ b/thcrap/thcrap.def
@@ -71,6 +71,11 @@ EXPORTS
 	runconfig_get
 	runconfig_set
 	runconfig_title_get
+	globalconfig_get_boolean
+	globalconfig_set_boolean
+	globalconfig_get_integer
+	globalconfig_set_integer
+	globalconfig_release
 
 	; Initialization
 	; --------------

--- a/thcrap/thcrap.def
+++ b/thcrap/thcrap.def
@@ -67,6 +67,7 @@ EXPORTS
 	PROJECT_NAME_SHORT
 	PROJECT_VERSION
 	PROJECT_VERSION_STRING
+	PROJECT_BRANCH
 	runconfig_get
 	runconfig_set
 	runconfig_title_get

--- a/thcrap_configure/src/configure.cpp
+++ b/thcrap_configure/src/configure.cpp
@@ -311,6 +311,8 @@ end:
 	json_decref(url_cache);
 	json_decref(id_cache);
 
+	globalconfig_release();
+	
 	thcrap_update_exit_wrapper();
 	con_end();
 	return 0;

--- a/thcrap_loader/src/loader.cpp
+++ b/thcrap_loader/src/loader.cpp
@@ -255,5 +255,6 @@ end:
 	json_decref(games_js);
 	json_decref(run_cfg);
 	runconfig_set(NULL);
+	globalconfig_release();
 	return ret;
 }

--- a/thcrap_update/src/loader_update.cpp
+++ b/thcrap_update/src/loader_update.cpp
@@ -526,34 +526,11 @@ BOOL loader_update_with_UI(const char *exe_fn, char *args, const char *game_id_f
 	state.args = args;
 	state.state = STATE_INIT;
 
-	errno = 0;
-	state.update_at_exit = globalconfig_get_boolean("update_at_exit");
-	if (errno > 0) {
-		globalconfig_set_boolean("update_at_exit", false);
-		state.update_at_exit = false;
-	}
-
-	errno = 0;
-	state.background_updates = globalconfig_get_boolean("background_updates");
-	if (errno > 0) {
-		globalconfig_set_boolean("background_updates", true);
-		state.background_updates = true;
-	}
+	state.update_at_exit = globalconfig_get_boolean("update_at_exit", false);
+	state.background_updates = globalconfig_get_boolean("background_updates", true);
+	state.time_between_updates = (int)globalconfig_get_integer("time_between_updates", 5);
+	state.update_others = globalconfig_get_boolean("update_others", true);
 	
-	state.time_between_updates = (int)globalconfig_get_integer("time_between_updates");
-	
-	if (state.time_between_updates == 0) {
-		globalconfig_set_integer("time_between_updates", 5);
-		state.time_between_updates = 5;
-	}
-
-	errno = 0;
-	state.update_others = globalconfig_get_boolean("update_others");
-	if (errno > 0) {
-		globalconfig_set_boolean("update_others", true);
-		state.update_others = true;
-	}
-
 	SetLastError(0);
 	HANDLE hMap = CreateFileMapping(INVALID_HANDLE_VALUE, nullptr, PAGE_READWRITE, 0, sizeof(HWND), "thcrap update UI");
 	bool mapExists = GetLastError() == ERROR_ALREADY_EXISTS;
@@ -681,7 +658,12 @@ BOOL loader_update_with_UI(const char *exe_fn, char *args, const char *game_id_f
 		SendMessage(state.hwnd[HWND_MAIN], WM_CLOSE, 0, 0);
 	}
 
-	end:
+	end:	
+	globalconfig_set_boolean("update_at_exit", state.update_at_exit);
+	globalconfig_set_boolean("background_updates", state.background_updates);
+	globalconfig_set_integer("time_between_updates", state.time_between_updates);
+	globalconfig_set_boolean("update_others", state.update_others);
+	
 	DeleteCriticalSection(&state.cs);
 	CloseHandle(state.hThread);
 	CloseHandle(state.event_created);

--- a/thcrap_update/src/loader_update.cpp
+++ b/thcrap_update/src/loader_update.cpp
@@ -526,33 +526,31 @@ BOOL loader_update_with_UI(const char *exe_fn, char *args, const char *game_id_f
 	state.args = args;
 	state.state = STATE_INIT;
 
-	json_t *config = json_load_file_report("config/config.js");
-	if (!config) {
-		config = json_object();
-	}
-	json_t *update_at_exit_object = json_object_get(config, "update_at_exit");
-	if (update_at_exit_object) {
-		state.update_at_exit = json_boolean_value(update_at_exit_object);
-	}
-	else {
+	errno = 0;
+	state.update_at_exit = globalconfig_get_boolean("update_at_exit");
+	if (errno > 0) {
+		globalconfig_set_boolean("update_at_exit", false);
 		state.update_at_exit = false;
 	}
-	json_t *background_updates_object = json_object_get(config, "background_updates");
-	if (background_updates_object) {
-		state.background_updates = json_boolean_value(background_updates_object);
-	}
-	else {
+
+	errno = 0;
+	state.background_updates = globalconfig_get_boolean("background_updates");
+	if (errno > 0) {
+		globalconfig_set_boolean("background_updates", true);
 		state.background_updates = true;
 	}
-	state.time_between_updates = (int)json_integer_value(json_object_get(config, "time_between_updates"));
+	
+	state.time_between_updates = (int)globalconfig_get_integer("time_between_updates");
+	
 	if (state.time_between_updates == 0) {
+		globalconfig_set_integer("time_between_updates", 5);
 		state.time_between_updates = 5;
 	}
-	json_t *update_others_object = json_object_get(config, "update_others");
-	if (update_others_object) {
-		state.update_others = json_boolean_value(update_others_object);
-	}
-	else {
+
+	errno = 0;
+	state.update_others = globalconfig_get_boolean("update_others");
+	if (errno > 0) {
+		globalconfig_set_boolean("update_others", true);
 		state.update_others = true;
 	}
 
@@ -684,13 +682,6 @@ BOOL loader_update_with_UI(const char *exe_fn, char *args, const char *game_id_f
 	}
 
 	end:
-	json_object_set_new(config, "update_at_exit", json_boolean(state.update_at_exit));
-	json_object_set_new(config, "background_updates", json_boolean(state.background_updates));
-	json_object_set_new(config, "time_between_updates", json_integer(state.time_between_updates));
-	json_object_set_new(config, "update_others", json_boolean(state.update_others));
-	json_dump_file(config, "config/config.js", JSON_INDENT(2) | JSON_SORT_KEYS);
-	json_decref(config);
-
 	DeleteCriticalSection(&state.cs);
 	CloseHandle(state.hThread);
 	CloseHandle(state.event_created);

--- a/thcrap_update/src/notify.cpp
+++ b/thcrap_update/src/notify.cpp
@@ -20,6 +20,8 @@ static UINT self_msg_type[] = {
 	MB_ICONERROR, // SELF_NO_SIG
 	MB_ICONERROR, // SELF_SIG_FAIL
 	MB_ICONINFORMATION, // SELF_REPLACE_ERROR
+	MB_ICONEXCLAMATION, // SELF_NO_NETPATHS
+	MB_ICONEXCLAMATION, // SELF_NO_EXISTING_BRANCH
 };
 
 static const char *self_header_failure =
@@ -86,7 +88,24 @@ static const char *self_body[] = {
 	"\n"
 	"For further information about this new release, visit\n"
 	"\n"
-	"\t${desc_url}"
+	"\t${desc_url}",
+	// SELF_NO_NETPATHS
+	"An automatic update is required, but none of the servers is able to "
+	"provide infos regarding its location.\n"
+	"\n"
+	"The latest stable version can be found at\n"
+	"\n"
+	"\t${desc_url}",
+	// SELF_NO_EXISTING_BRANCH
+	"An automatic update is required, but the server doesn't know anything "
+	"about the running version, thus no update has been done.\n"
+	"\n"
+	"The latest stable release can be found at\n"
+	"\n"
+	"\t${desc_url}\n"
+	"\n"
+	"An automatic update will be attempted on the next run, unless "
+	"otherwise specified"
 };
 
 const char *self_sig_error =

--- a/thcrap_update/src/notify.cpp
+++ b/thcrap_update/src/notify.cpp
@@ -164,7 +164,7 @@ int update_notify_thcrap(void)
 
 	// Write message
 	// Default is false, and the value is going to be written later anyway. Doing it now would result in a useless IO write
-	if (globalconfig_get_boolean("skip_check_mbox")) {
+	if (globalconfig_get_boolean("skip_check_mbox", false)) {
 		log_print("---------------------------\n");
 		log_printf("%s\n", self_msg);
 		log_print("---------------------------\n");

--- a/thcrap_update/src/notify.cpp
+++ b/thcrap_update/src/notify.cpp
@@ -20,8 +20,9 @@ static UINT self_msg_type[] = {
 	MB_ICONERROR, // SELF_NO_SIG
 	MB_ICONERROR, // SELF_SIG_FAIL
 	MB_ICONINFORMATION, // SELF_REPLACE_ERROR
-	MB_ICONEXCLAMATION, // SELF_NO_NETPATHS
-	MB_ICONEXCLAMATION, // SELF_NO_EXISTING_BRANCH
+	MB_ICONERROR, // SELF_VERSION_CHECK_ERROR
+	MB_ICONEXCLAMATION, // SELF_INVALID_NETPATH
+	MB_ICONEXCLAMATION, // SELF_NO_TARGET_VERSION
 };
 
 static const char *self_header_failure =
@@ -89,16 +90,21 @@ static const char *self_body[] = {
 	"For further information about this new release, visit\n"
 	"\n"
 	"\t${desc_url}",
-	// SELF_NO_NETPATHS
-	"An automatic update is required, but none of the servers is able to "
-	"provide infos regarding its location.\n"
+	// SELF_VERSION_CHECK_ERROR
+	"An error occured while looking for an update. No update will be done\n"
+	"\n"
+	"An automatic update will be attempted on the next run, unless "
+	"otherwise specified",
+	// SELF_INVALID_NETPATH
+	"An automatic update was attempted, but something is wrong with the "
+	"infos retrieved from the server.\n"
 	"\n"
 	"The latest stable version can be found at\n"
 	"\n"
 	"\t${desc_url}",
-	// SELF_NO_EXISTING_BRANCH
-	"An automatic update is required, but the server doesn't know anything "
-	"about the running version, thus no update has been done.\n"
+	// SELF_NO_TARGET_VERSION
+	"An update couldn't be found, since the server doesn't know which is "
+	"the latest version for this build.\n"
 	"\n"
 	"The latest stable release can be found at\n"
 	"\n"
@@ -120,40 +126,58 @@ int update_notify_thcrap(void)
 	self_result_t ret = SELF_NO_UPDATE;
 	json_t *run_cfg = runconfig_get();
 
-	json_t *patches = json_object_get(run_cfg, "patches");
-	size_t i;
-	json_t *patch_info;
-	uint32_t min_build = 0;
-	json_array_foreach(patches, i, patch_info) {
-		auto cur_min_build = json_object_get_hex(patch_info, "thcrap_version_min");
-		min_build = max(min_build, cur_min_build);
+	const char *thcrap_dir = json_object_get_string(run_cfg, "thcrap_dir");
+	
+	char *arc_fn = NULL;
+	const char *self_msg = NULL;
+	ret = self_update(thcrap_dir, &arc_fn);
+	if (ret == SELF_NO_UPDATE) {
+		return ret;
 	}
-	if(min_build > PROJECT_VERSION()) {
-		ret = SELF_OK;
-		const char *thcrap_dir = json_object_get_string(run_cfg, "thcrap_dir");
-		const char *thcrap_url = json_object_get_string(run_cfg, "thcrap_url");
-		char *arc_fn = NULL;
-		const char *self_msg = NULL;
-		char min_build_str[11];
-		str_hexdate_format(min_build_str, min_build);
-		ret = self_update(thcrap_dir, &arc_fn);
-		strings_sprintf(SELF_MSG_SLOT,
-			"%s%s",
-			ret != SELF_OK ? self_header_failure : "",
-			self_body[ret]
-		);
-		if(ret == SELF_NO_SIG || ret == SELF_SIG_FAIL) {
-			strings_strcat(SELF_MSG_SLOT, self_sig_error);
-		}
-		strings_replace(SELF_MSG_SLOT, "${project}", PROJECT_NAME());
-		strings_replace(SELF_MSG_SLOT, "${project_short}", PROJECT_NAME_SHORT());
-		strings_replace(SELF_MSG_SLOT, "${build}", min_build_str);
-		strings_replace(SELF_MSG_SLOT, "${thcrap_dir}", thcrap_dir);
-		strings_replace(SELF_MSG_SLOT, "${desc_url}", thcrap_url);
-		self_msg = strings_replace(SELF_MSG_SLOT, "${arc_fn}", arc_fn);
+	
+	const char* self_header;
+	const bool vcheck_error = (ret == SELF_VERSION_CHECK_ERROR || ret == SELF_NO_TARGET_VERSION);
+	// Since we don't have the name of the newest version when this kind of values appear,
+	// we don't need to add self_header_failure
+	if (ret == SELF_OK || vcheck_error) {
+		self_header = "";
+	} else {
+		self_header = self_header_failure;
+	}
+	
+	strings_sprintf(SELF_MSG_SLOT,
+		"%s%s",
+		self_header,
+		self_body[ret]
+	);
+	
+	const char* thcrap_url = json_object_get_string(run_cfg, "thcrap_url");
+	if(ret == SELF_NO_SIG || ret == SELF_SIG_FAIL) {
+		strings_strcat(SELF_MSG_SLOT, self_sig_error);
+	}
+	strings_replace(SELF_MSG_SLOT, "${project}", PROJECT_NAME());
+	strings_replace(SELF_MSG_SLOT, "${project_short}", PROJECT_NAME_SHORT());
+	strings_replace(SELF_MSG_SLOT, "${build}", self_get_target_version());
+	strings_replace(SELF_MSG_SLOT, "${thcrap_dir}", thcrap_dir);
+	strings_replace(SELF_MSG_SLOT, "${desc_url}", thcrap_url);
+	self_msg = strings_replace(SELF_MSG_SLOT, "${arc_fn}", arc_fn);
+
+	// Write message
+	// Default is false, and the value is going to be written later anyway. Doing it now would result in a useless IO write
+	if (globalconfig_get_boolean("skip_check_mbox")) {
+		log_print("---------------------------\n");
+		log_printf("%s\n", self_msg);
+		log_print("---------------------------\n");
+	}
+	else {
 		log_mboxf(NULL, MB_OK | self_msg_type[ret], self_msg);
-		SAFE_FREE(arc_fn);
 	}
+
+	// This isn't meant to be used by the user. skip_check_mbox just persists the last vcheck_error
+	globalconfig_set_boolean("skip_check_mbox", vcheck_error);
+	
+	SAFE_FREE(arc_fn);
+	
 	return ret;
 }
 

--- a/thcrap_update/src/self.cpp
+++ b/thcrap_update/src/self.cpp
@@ -15,8 +15,6 @@
 #define TEMP_FN_LEN 41
 
 const char *NETPATHS_FN = "thcrap_uris.js";
-const char *ARC_FN = "thcrap_brliron.zip";
-const char *SIG_FN = "thcrap_brliron.zip.sig";
 const char *PREFIX_BACKUP = "thcrap_old_%s";
 const char *PREFIX_NEW = "thcrap_new_";
 const char *EXT_NEW = ".zip";
@@ -514,7 +512,7 @@ static const char* self_get_netpath(json_t* netpaths_json)
 	const char* netpath = nullptr;
 	const char* branch = PROJECT_BRANCH();
 	json_t* branch_json = json_object_get(netpaths_json, branch);
-	// TODO By default it returns here with a literal that represents an invalid value. Shall I add a "fallback on stable" option in config?
+	// TODO By default it returns here with a literal that represents an invalid value. Shall I add a 'fallback on stable' option in config?
 	if (!branch_json)
 	{
 		return netpath;
@@ -594,32 +592,25 @@ self_result_t self_update(const char *thcrap_dir, char **arc_fn_ptr)
 	}
 	defer(netpaths = json_decref_safe(netpaths));
 
-	const char* base_netpath = self_get_netpath(netpaths);
-	if (base_netpath == nullptr)
+	const char* netpath = self_get_netpath(netpaths);
+	if (netpath == nullptr)
 	{
 		return SELF_NO_EXISTING_BRANCH;
 	}
 
-	const size_t arc_netpath_len = strlen(base_netpath) + strlen(ARC_FN) + 1;
-
-	VLA(char, arc_netpath, arc_netpath_len);
-	defer(VLA_FREE(arc_netpath));
-	strcpy(arc_netpath, base_netpath);
-	strcat(arc_netpath, ARC_FN);
-
-	auto arc_dl = srv.download(arc_netpath, nullptr);
+	auto arc_dl = srv.download(netpath, nullptr);
 
 	defer(SAFE_FREE(arc_dl.file_buffer));
 	if(!arc_dl.file_buffer) {
 		return SELF_SERVER_ERROR;
 	}
 
-	const size_t sig_netpath_len = strlen(base_netpath) + strlen(SIG_FN) + 1;
+	const size_t sig_netpath_len = strlen(netpath) + strlen(".sig") + 1;
 
 	VLA(char, sig_netpath, sig_netpath_len);
 	defer(VLA_FREE(sig_netpath));
-	strcpy(sig_netpath, base_netpath);
-	strcat(sig_netpath, SIG_FN);
+	strcpy(sig_netpath, netpath);
+	strcat(sig_netpath, ".sig");
 
 	auto sig = srv.download_valid_json(sig_netpath);
 	if(!sig) {

--- a/thcrap_update/src/self.cpp
+++ b/thcrap_update/src/self.cpp
@@ -513,32 +513,27 @@ static const char* self_get_netpath(json_t* netpaths_json)
 	const char* branch = PROJECT_BRANCH();
 	json_t* branch_json = json_object_get(netpaths_json, branch);
 	// TODO By default it returns here with a literal that represents an invalid value. Shall I add a 'fallback on stable' option in config?
-	if (!branch_json)
-	{
+	if (!branch_json) {
 		return netpath;
 	}
 
 	const char* version;
 	const json_t* value;
 	uint32_t min_milestone = MAXDWORD;
-	json_object_foreach(branch_json, version, value)
-	{
+	json_object_foreach(branch_json, version, value) {
 		errno = 0;
 		// Check if the string isn't an hex
-		if (!strtoul(version, NULL, 16) || errno > 0)
-		{
+		if (!strtoul(version, NULL, 16) || errno > 0) {
 			continue;
 		}
 		
 		size_t milestone = str_address_value(version, nullptr, nullptr);
-		if (milestone > PROJECT_VERSION() && milestone < min_milestone)
-		{
+		if (milestone > PROJECT_VERSION() && milestone < min_milestone) {
 			netpath = json_string_value(value);
 			min_milestone = milestone;
 		}
 	}
-	if (min_milestone == MAXDWORD)
-	{
+	if (min_milestone == MAXDWORD) {
 		netpath = json_object_get_string(branch_json, "latest");
 	}
 	return netpath;
@@ -586,15 +581,13 @@ self_result_t self_update(const char *thcrap_dir, char **arc_fn_ptr)
 	auto srv = self_servers();
 
 	auto netpaths = srv.download_valid_json(NETPATHS_FN);
-	if (!netpaths)
-	{
+	if (!netpaths) {
 		return SELF_NO_NETPATHS;
 	}
 	defer(netpaths = json_decref_safe(netpaths));
 
 	const char* netpath = self_get_netpath(netpaths);
-	if (netpath == nullptr)
-	{
+	if (netpath == nullptr) {
 		return SELF_NO_EXISTING_BRANCH;
 	}
 

--- a/thcrap_update/src/self.cpp
+++ b/thcrap_update/src/self.cpp
@@ -518,6 +518,8 @@ self_result_t self_update(const char *thcrap_dir, char **arc_fn_ptr)
 	HCRYPTPROV hCryptProv = 0;
 	HCRYPTHASH hHash = 0;
 
+	log_printf("Checking for engine updates...\n");
+
 	auto srv = self_servers();
 
 	auto netpaths = srv.download_valid_json(NETPATHS_FN);

--- a/thcrap_update/src/self.cpp
+++ b/thcrap_update/src/self.cpp
@@ -14,7 +14,7 @@
 
 #define TEMP_FN_LEN 41
 
-const char *NETPATHS_FN = "thcrap_uris.js";
+const char *NETPATHS_FN = "thcrap_update.js";
 const char *PREFIX_BACKUP = "thcrap_old_%s";
 const char *PREFIX_NEW = "thcrap_new_";
 const char *EXT_NEW = ".zip";
@@ -522,12 +522,12 @@ static const char* self_get_netpath(json_t* netpaths_json)
 	uint32_t min_milestone = MAXDWORD;
 	json_object_foreach(branch_json, version, value) {
 		errno = 0;
+		uint32_t milestone = strtoul(version, NULL, 16);
 		// Check if the string isn't an hex
-		if (!strtoul(version, NULL, 16) || errno > 0) {
+		if (errno > 0 || !milestone) {
 			continue;
 		}
 		
-		size_t milestone = str_address_value(version, nullptr, nullptr);
 		if (milestone > PROJECT_VERSION() && milestone < min_milestone) {
 			netpath = json_string_value(value);
 			min_milestone = milestone;

--- a/thcrap_update/src/self.cpp
+++ b/thcrap_update/src/self.cpp
@@ -19,6 +19,8 @@ const char *PREFIX_BACKUP = "thcrap_old_%s";
 const char *PREFIX_NEW = "thcrap_new_";
 const char *EXT_NEW = ".zip";
 
+static char update_version[sizeof("0x20010101")];
+
 static servers_t& self_servers()
 {
 	// Yup, hardcoded download URLs. After all, these should be a property
@@ -507,38 +509,6 @@ end:
 	return ret;
 }
 
-static const char* self_get_netpath(json_t* netpaths_json)
-{
-	const char* netpath = nullptr;
-	const char* branch = PROJECT_BRANCH();
-	json_t* branch_json = json_object_get(netpaths_json, branch);
-	// TODO By default it returns here with a literal that represents an invalid value. Shall I add a 'fallback on stable' option in config?
-	if (!branch_json) {
-		return netpath;
-	}
-
-	const char* version;
-	const json_t* value;
-	uint32_t min_milestone = MAXDWORD;
-	json_object_foreach(branch_json, version, value) {
-		errno = 0;
-		uint32_t milestone = strtoul(version, NULL, 16);
-		// Check if the string isn't an hex
-		if (errno > 0 || !milestone) {
-			continue;
-		}
-		
-		if (milestone > PROJECT_VERSION() && milestone < min_milestone) {
-			netpath = json_string_value(value);
-			min_milestone = milestone;
-		}
-	}
-	if (min_milestone == MAXDWORD) {
-		netpath = json_object_get_string(branch_json, "latest");
-	}
-	return netpath;
-}
-
 self_result_t self_update(const char *thcrap_dir, char **arc_fn_ptr)
 {
 	self_result_t ret;
@@ -548,6 +518,63 @@ self_result_t self_update(const char *thcrap_dir, char **arc_fn_ptr)
 	HCRYPTPROV hCryptProv = 0;
 	HCRYPTHASH hHash = 0;
 
+	auto srv = self_servers();
+
+	auto netpaths = srv.download_valid_json(NETPATHS_FN);
+	if (!netpaths) {
+		return SELF_VERSION_CHECK_ERROR;
+	}
+	defer(netpaths = json_decref_safe(netpaths));
+
+	const char* branch = PROJECT_BRANCH();
+	json_t* branch_json = json_object_get(netpaths, branch);
+	if (!branch_json) {
+		return SELF_NO_UPDATE;
+	}
+	defer(branch_json = json_decref_safe(branch_json));
+
+	auto latest_version = json_object_get_hex(branch_json, "version");
+	if (!latest_version) {
+		return SELF_NO_TARGET_VERSION;
+	}
+
+	if (latest_version <= PROJECT_VERSION()) {
+		return SELF_NO_UPDATE;
+	}
+
+	// Since we already have downloaded NETPATHS_FN and we are trying to resolve the
+	// next exact version, we might as well get the right path immediately
+	const char* version_key;
+	const json_t* value;
+	const char* netpath = nullptr;
+	auto target_version = latest_version;
+	json_object_foreach(branch_json, version_key, value) {
+		errno = 0;
+		uint32_t milestone = strtoul(version_key, NULL, 16);
+		// Check if the string isn't an hex
+		if (errno > 0 || !milestone) {
+			continue;
+		}
+
+		if (milestone > PROJECT_VERSION() && milestone < target_version) {
+			netpath = json_string_value(value);
+			target_version = milestone;
+		}
+	}
+
+	if (target_version == latest_version) {
+		netpath = json_object_get_string(branch_json, "latest");
+	}
+
+	// We know for sure which version we need
+	str_hexdate_format(update_version, target_version);
+	
+	if (!netpath) {
+		// If netpath is still null, branch_json is malformed.
+		return SELF_INVALID_NETPATH;
+	}
+
+	// We are now trying an update
 	smartdlg_state_t window;
 	defer(smartdlg_close(&window));
 
@@ -577,19 +604,6 @@ self_result_t self_update(const char *thcrap_dir, char **arc_fn_ptr)
 		nullptr, 0, self_window_create_and_run, &window, 0, &window.thread_id
 	);
 	WaitForSingleObject(window.event_created, INFINITE);
-
-	auto srv = self_servers();
-
-	auto netpaths = srv.download_valid_json(NETPATHS_FN);
-	if (!netpaths) {
-		return SELF_NO_NETPATHS;
-	}
-	defer(netpaths = json_decref_safe(netpaths));
-
-	const char* netpath = self_get_netpath(netpaths);
-	if (netpath == nullptr) {
-		return SELF_NO_EXISTING_BRANCH;
-	}
 
 	auto arc_dl = srv.download(netpath, nullptr);
 
@@ -644,3 +658,9 @@ self_result_t self_update(const char *thcrap_dir, char **arc_fn_ptr)
 	}
 	return ret;
 }
+
+const char* self_get_target_version()
+{
+	return update_version;
+}
+

--- a/thcrap_update/src/self.h
+++ b/thcrap_update/src/self.h
@@ -19,10 +19,15 @@ typedef enum {
 	SELF_NO_SIG,
 	SELF_SIG_FAIL,
 	SELF_REPLACE_ERROR,
-	SELF_NO_NETPATHS,
-	SELF_NO_EXISTING_BRANCH,
+	SELF_VERSION_CHECK_ERROR,
+	SELF_INVALID_NETPATH,
+	SELF_NO_TARGET_VERSION,
 } self_result_t;
 
 // Performs an update of the thcrap installation in [thcrap_dir].
 // [arc_fn_ptr] receives the name of the archive downloaded.
 self_result_t self_update(const char *thcrap_dir, char **arc_fn_ptr);
+
+// Returns a string representation of the next version. If no update was
+// attempted or if no info could be retrieved from the server it returns a blank string.
+const char* self_get_target_version();

--- a/thcrap_update/src/self.h
+++ b/thcrap_update/src/self.h
@@ -19,6 +19,8 @@ typedef enum {
 	SELF_NO_SIG,
 	SELF_SIG_FAIL,
 	SELF_REPLACE_ERROR,
+	SELF_NO_NETPATHS,
+	SELF_NO_EXISTING_BRANCH,
 } self_result_t;
 
 // Performs an update of the thcrap installation in [thcrap_dir].


### PR DESCRIPTION
With this thcrap is able to look for updates without depending on the repository and pick different URLs depending on information stored on its update server.

- Now a PROJECT_BRANCH property is globally available, allowing for different versions of thcrap to be created and maintained differently without having to modify thcrap_update.dll;
- Instead of cycling through every patch.js stored in the repository searching for the highest "thcrap_version_min", it tries to download a json ("thcrap_update.js") from one of its update servers.
- thcrap_update.js contains a "branch" object, and every branch object contains its latest version number, the path to download the latest version, plus a list of optional milestones, which have to be downloaded before every other update (an example is available [here](https://gist.github.com/DoremyR3d/24402662f316d72e8d6bf8a0146a916e));
- Failing to download thcrap_update.js generates an error similar to the ones triggered when an update fails. Multiple consequential error of this type will be suppressed while still logging;
- config.js is now globally available and is accessible through accessors that handle type conversions and errors. Every change is immediately persisted (different processes/instances may generate unintended behavior. This isn't really a new problem, but it's something to keep in mind).