### PR TITLE
Let codecaves refer to each other

### DIFF
--- a/thcrap/src/binhack.cpp
+++ b/thcrap/src/binhack.cpp
@@ -325,7 +325,12 @@ int codecaves_apply(json_t *codecaves) {
 	size_t codecave_count = 0, codecaves_total_size = 0;
 
 	json_object_foreach(codecaves, codecave_name, hack) {
-		codecaves_total_size += binhack_calc_size(json_object_get_string(hack, "code"));
+		const char* code = json_string_value(hack);
+		if (!code) {
+			continue;
+		}
+
+		codecaves_total_size += binhack_calc_size(code);
 		codecaves_total_size += codecave_sep_size;
 	}
 


### PR DESCRIPTION
Fixes usage of `[codecave:foo]` inside another codecave.

(unfortunately, there seems to be another bug somewhere with addresses like `[Rx424ab3]` that prevents me from testing this as well as I would like to.  But that bug exists even without this modification, so 🤷‍♂)

Also fixes the first loop to read the correct JSON layout so that it allocates the right size. (previously this was probably only working because VirtualAlloc always allocates at least one page)