### PR TITLE
make options actually settable in user config

### DIFF
--- a/thcrap/src/runconfig.cpp
+++ b/thcrap/src/runconfig.cpp
@@ -171,6 +171,11 @@ void runconfig_load(json_t *file, int flags)
 		run_cfg.json = tmp;
 	}
 
+	value = json_object_get(run_cfg.json, "options");
+	if (value) {
+		json_object_set(file, "options", value);
+	}
+
 	auto set_string_if_exist = [file, can_overwrite](const char* key, std::string& out) {
 		json_t *value = json_object_get(file, key);
 		if (value && (out.empty() || can_overwrite)) {

--- a/thcrap/src/runconfig.cpp
+++ b/thcrap/src/runconfig.cpp
@@ -171,6 +171,10 @@ void runconfig_load(json_t *file, int flags)
 		run_cfg.json = tmp;
 	}
 
+	// Copy the merged options back into file so binhacks see them (replacing 'file' with
+	// a shallow copy so that this does not become a side effect)
+	file = json_copy(file);
+	defer(json_decref(file));
 	value = json_object_get(run_cfg.json, "options");
 	if (value) {
 		json_object_set(file, "options", value);


### PR DESCRIPTION
Currently,
```json
{
  "patches": [
    {"archive": "repos/nmlgc/base_tsa/"},
    {"archive": "lol/test/"},
  ], "options": {
    "fun": { "val": 1000 }
  }
}
```
in `config/*.js` does *not* actually override the value of `option:fun`.  This is because a JSON with the correctly-merged `"options"` object is constructed in `run_cfg.json` (and thus printed in the logfile), but this is not the JSON object that is actually used during binhack and codecave compilation!

This PR fixes this by copying the merged `"options"` object back to `file`.

---

An alternative fix would be to change these lines to use `run_cfg.json`:

https://github.com/thpatch/thcrap/blob/df99529271d0bdf08833df3688cfd38ee00a013e/thcrap/src/runconfig.cpp#L226-L235

This alternative would provide the questionable capability of letting `config/*.js` control codecaves and binhacks, but with the benefit that the object printed to the logfile would more closely match what's used at runtime.  (since setting these properties in this file already affects the JSON that is logged)