### PR TITLE
Use utf8_to_utf[16/32]_masking as general string conversion function

### DIFF
--- a/thcrap/src/patchfile.cpp
+++ b/thcrap/src/patchfile.cpp
@@ -760,43 +760,15 @@ void patch_opts_from_json(json_t *opts) {
 						case 16:
 							entry.type = PVT_STRING16;
 							entry.str16.len = narrow_len * sizeof(char16_t);
-							if (char16_t* str_16 = (char16_t*)malloc(narrow_len * sizeof(char16_t))) {
-								const char* opt_str_end = opt_str + narrow_len;
-								size_t c = mbrtoc16(NULL, NULL, 0, NULL);
-								for (char16_t* write_str = str_16; c = mbrtoc16(write_str, opt_str, PtrDiffStrlen(opt_str_end, opt_str), NULL); ++write_str) {
-									if (c > 0) opt_str += c;
-									else if (c > -3) break;
-								}
-								if unexpected(c != 0) {
-									free(str_16);
-									log_printf("ERROR: invalid char16 conversion for string16 option %s\n", key);
-									continue;
-								}
-								entry.str16.ptr = str_16;
-								break;
-							}
-							else {
+							if (!(entry.str16.ptr = utf8_to_utf16(opt_str))) {
+								log_printf("ERROR: invalid char16 conversion for string16 option %s\n", key);
 								continue;
 							}
 						case 32:
 							entry.type = PVT_STRING32;
 							entry.str32.len = narrow_len * sizeof(char32_t);
-							if (char32_t* str_32 = (char32_t*)malloc(narrow_len * sizeof(char32_t))) {
-								const char* opt_str_end = opt_str + narrow_len;
-								size_t c = mbrtoc32(NULL, NULL, 0, NULL);
-								for (char32_t* write_str = str_32; c = mbrtoc32(write_str, opt_str, PtrDiffStrlen(opt_str_end, opt_str), NULL); ++write_str) {
-									if (c > 0) opt_str += c;
-									else if (c > -3) break;
-								}
-								if unexpected(c != 0) {
-									free(str_32);
-									log_printf("ERROR: invalid char32 conversion for string32 option %s\n", key);
-									continue;
-								}
-								entry.str32.ptr = str_32;
-								break;
-							}
-							else {
+							if (!(entry.str32.ptr = utf8_to_utf32(opt_str))) {
+								log_printf("ERROR: invalid char32 conversion for string32 option %s\n", key);
 								continue;
 							}
 						default:

--- a/thcrap/src/util.h
+++ b/thcrap/src/util.h
@@ -360,127 +360,9 @@ int _asprintf(char** buffer_ret, const char* format, ...);
 
 #define PtrDiffStrlen(end_ptr, start_ptr) ((size_t)((end_ptr) - (start_ptr)))
 
-THCRAP_API TH_CALLER_FREE inline char16_t* utf8_to_utf16(const char* utf8_str) {
-	if (utf8_str) {
-		size_t utf8_len = strlen(utf8_str) + 1;
-		char16_t* utf16_str = (char16_t*)malloc(utf8_len * sizeof(char16_t));
-		mbstate_t state;
-		memset(&state, 0, sizeof(state));
-		char16_t* utf16_write = utf16_str - 1;
-		size_t c;
-		while (1) {
-			switch (c = mbrtoc16(++utf16_write, utf8_str, utf8_len, &state)) {
-				case 0:				return utf16_str;
-				case -1: case -2:	goto BreakAll;
-				case -3:			continue;
-				default:			utf8_str += c; utf8_len -= c;
-			}
-		}
-	BreakAll:
-		free(utf16_str);
-	}
-	return NULL;
-}
-
 #include <intrin.h>
 
-THCRAP_API TH_CALLER_FREE inline char16_t* utf8_to_utf16_bit_test_reset(const char* utf8_str) {
-	if (utf8_str) {
-		char16_t* utf16_str = (char16_t*)malloc((strlen(utf8_str) + 1) * sizeof(char16_t));
-		char16_t* utf16_write = utf16_str;
-
-		uint32_t codepoint = 0;
-		int8_t multibyte_index = -1; // Signed = Single byte, Unsigned = Multibyte
-		bool is_four_bytes = false;
-		while (1) {
-			uint32_t cur_byte = (uint8_t)*utf8_str++; // Zero Extend
-			if (!_bittestandreset((long*)&cur_byte, 7)) {
-				*utf16_write++ = cur_byte; // Single byte character
-				if (cur_byte != '\0') continue;
-				if (multibyte_index >= 0) break; // ERROR: Unfinished multi-byte sequence
-				return utf16_str;
-			}
-			if (_bittestandreset((long*)&cur_byte, 6)) { // Leading byte
-				if (multibyte_index >= 0) break; // ERROR: Leading byte before end of previous sequence
-				multibyte_index = 1 + _bittestandreset((long*)&cur_byte, 5); // Test 3 byte bit
-				if (multibyte_index == 2) {
-					is_four_bytes = _bittestandreset((long*)&cur_byte, 4); // Test 4 byte bit
-					if (is_four_bytes & (bool)_bittest((long*)&cur_byte, 3)) break; // ERROR: No 5 byte sequences
-					multibyte_index += is_four_bytes;
-				}
-			}
-			if (multibyte_index < 0) break; // ERROR: Trailing byte before leading byte
-			codepoint |= cur_byte << 6 * (uint8_t)multibyte_index; // Accumulate to codepoint
-			if (--multibyte_index < 0) { // Sequence is finished
-				if (!is_four_bytes) {
-					*utf16_write++ = codepoint;
-					codepoint = 0;
-				}
-				else {
-					is_four_bytes = false;
-					*(uint32_t*)utf16_write = 0xDC00D800 | // Surrogate Base
-						(codepoint & ~0x103FF) >> 10 | // High Surrogate
-						(codepoint & 0x3FF) << 16; // Low Surrogate
-					utf16_write += 2;
-					codepoint = 0;
-				}
-			}
-		}
-		free(utf16_str);
-	}
-	return NULL;
-}
-
-THCRAP_API TH_CALLER_FREE inline char16_t* utf8_to_utf16_bit_scan(const char* utf8_str) {
-	if (utf8_str) {
-		char16_t* utf16_str = (char16_t*)malloc((strlen(utf8_str) + 1) * sizeof(char16_t));
-		char16_t* utf16_write = utf16_str;
-
-		uint32_t codepoint = 0;
-		int8_t multibyte_index = -1; // Signed = Single byte, Unsigned = Multibyte
-		bool is_four_bytes = false;
-		while (1) {
-			int8_t cur_byte = *utf8_str++;
-			uint32_t pad_cur_byte = (uint8_t)cur_byte; // Zero Extend
-			if (cur_byte >= 0) {
-				*utf16_write++ = pad_cur_byte; // Single byte character
-				if (cur_byte != '\0') continue;
-				if (multibyte_index >= 0) break; // ERROR: Unfinished multi-byte sequence
-				return utf16_str;
-			}
-			uint32_t BitScan = (uint8_t)~cur_byte; // Flip bits THEN Zero Extend
-			(void)_BitScanReverse((unsigned long*)&BitScan, BitScan); // Count leading zero bits
-			uint8_t BitIndex = 6 - BitScan; // Convert to multibyte index
-			pad_cur_byte &= 0b01111111u >> BitIndex;
-			if (BitIndex) { // Leading byte
-				if (multibyte_index >= 0) break; // ERROR: Leading byte before end of previous sequence
-				if (BitIndex > 3) break; // ERROR: No 5 byte sequences
-				is_four_bytes = BitIndex == 3;
-				multibyte_index = BitIndex;
-			}
-			if (multibyte_index < 0) break; // ERROR: Trailing byte before leading byte
-			codepoint |= pad_cur_byte << 6 * (uint8_t)multibyte_index; // Accumulate to codepoint
-			if (--multibyte_index < 0) { // Sequence is finished
-				if (!is_four_bytes) {
-					*utf16_write++ = codepoint;
-					codepoint = 0;
-				}
-				else {
-					is_four_bytes = false;
-					*(uint32_t*)utf16_write = 0xDC00D800 | // Surrogate Base
-						(codepoint & ~0x103FF) >> 10 | // High Surrogate
-						(codepoint & 0x3FF) << 16; // Low Surrogate
-					utf16_write += 2;
-					codepoint = 0;
-				}
-			}
-		}
-		free(utf16_str);
-	}
-	return NULL;
-}
-
-THCRAP_API TH_CALLER_FREE inline char16_t* utf8_to_utf16_masking(const char* utf8_str) {
+THCRAP_API TH_CALLER_FREE inline char16_t* utf8_to_utf16(const char* utf8_str) {
 	if (utf8_str) {
 		char16_t* utf16_str = (char16_t*)malloc((strlen(utf8_str) + 1) * sizeof(char16_t));
 		char16_t* utf16_write = utf16_str;
@@ -540,21 +422,47 @@ THCRAP_API TH_CALLER_FREE inline char16_t* utf8_to_utf16_masking(const char* utf
 
 THCRAP_API TH_CALLER_FREE inline char32_t* utf8_to_utf32(const char* utf8_str) {
 	if (utf8_str) {
-		size_t utf8_len = strlen(utf8_str) + 1;
-		char32_t* utf32_str = (char32_t*)malloc(utf8_len * sizeof(char32_t));
-		mbstate_t state;
-		memset(&state, 0, sizeof(state));
-		char32_t* utf32_write = utf32_str - 1;
-		size_t c;
+		char32_t* utf32_str = (char32_t*)malloc((strlen(utf8_str) + 1) * sizeof(char32_t));
+		char32_t* utf32_write = utf32_str;
+
+		uint32_t temp;
+#define BitMask(value, mask) \
+		((bool)((value) & (mask)))
+#define BitMaskAndReset(value, mask) \
+		(temp = (value), temp != ((value) &= ~(mask)))
+#define BitMaskAndSet(value, mask) \
+		(temp = (value), temp != ((value) |= (mask)))
+#define BitMaskAndComplement(value, mask) \
+		(temp = (value), temp != ((value) ^= (mask)))
+
+		uint32_t codepoint = 0;
+		int8_t multibyte_index = -1; // Signed = Single byte, Unsigned = Multibyte
+		bool is_four_bytes = false;
 		while (1) {
-			switch (c = mbrtoc32(++utf32_write, utf8_str, utf8_len, &state)) {
-				case 0:				return utf32_str;
-				case -1: case -2:	goto BreakAll;
-				case -3:			continue;
-				default:			utf8_str += c; utf8_len -= c;
+			int32_t cur_byte = *utf8_str++; // Sign Extend
+			if (cur_byte >= 0) {
+				*utf32_write++ = cur_byte; // Single byte character
+				if (cur_byte != '\0') continue;
+				if (multibyte_index >= 0) break; // ERROR: Unfinished multibyte sequence
+				return utf32_str;
+			}
+			cur_byte &= 0b01111111; // Get rid of the sign extended bits
+			if (BitMaskAndReset(cur_byte, 0b01000000)) { // Leading byte
+				if (multibyte_index >= 0) break;  // ERROR: Leading byte before end of previous sequence
+				multibyte_index = 1 + BitMaskAndReset(cur_byte, 0b00100000); // Test 3 byte bit
+				if (multibyte_index == 2) {
+					is_four_bytes = BitMaskAndReset(cur_byte, 0b00010000); // Test 4 byte bit
+					if (is_four_bytes & BitMask(cur_byte, 0b00001000)) break; // ERROR: No 5 byte sequences
+					multibyte_index += is_four_bytes;
+				}
+			}
+			if (multibyte_index < 0) break; // ERROR: Trailing byte before leading byte
+			codepoint |= cur_byte << 6 * (uint8_t)multibyte_index; // Accumulate to codepoint
+			if (--multibyte_index < 0) { // Sequence is finished
+				*utf32_write++ = codepoint;
+				codepoint = 0;
 			}
 		}
-	BreakAll:
 		free(utf32_str);
 	}
 	return NULL;

--- a/thcrap_test/src/win32_utf8.cpp
+++ b/thcrap_test/src/win32_utf8.cpp
@@ -18,69 +18,6 @@ std::filesystem::path get_dll_source_path()
 	return exe_path;
 }
 
-TEST(NewUTF8Test, UTF8_TO_UTF16) {
-
-#define MakeUTFStrings(string) \
-	const char utf8_in[] = u8 ## string;\
-	const char16_t utf16[] = u ## string;\
-	const char32_t utf32[] = U ## string;
-
-	//MakeUTFStrings("Iñtërnâtiônà£ißætiøn☃💩");
-	//MakeUTFStrings("e💩🍙e");
-
-	const char utf8_in[] = u8"e💩🍙e";
-	const char16_t utf16[] = u"e💩🍙e";
-	const char32_t utf32[] = U"e💩🍙e";
-
-	const char16_t* utf16_out_bit_test_reset = utf8_to_utf16_bit_test_reset(utf8_in);
-	const char16_t* utf16_out_masking = utf8_to_utf16_masking(utf8_in);
-	const char16_t* utf16_out_bit_scan = utf8_to_utf16_bit_scan(utf8_in);
-	//const char32_t* utf32_out = utf8_to_utf32(utf8_in);
-
-	printf("\nConverted UTF8 Bytes: (Bit Test And Reset)\n");
-	for (size_t i = 0; i < elementsof(utf16); ++i) {
-		printf("%04hX", (uint32_t)utf16_out_bit_test_reset[i]);
-	}
-	
-	printf("\nConverted UTF8 Bytes: (Masking)\n");
-	for (size_t i = 0; i < elementsof(utf16); ++i) {
-		printf("%04hX", (uint32_t)utf16_out_masking[i]);
-	}
-
-	printf("\nConverted UTF8 Bytes: (Bit Scan)\n");
-	for (size_t i = 0; i < elementsof(utf16); ++i) {
-		printf("%04hX", (uint32_t)utf16_out_bit_scan[i]);
-	}
-	
-	printf("\nCorrect UTF16 Bytes:\n");
-	for (size_t i = 0; i < elementsof(utf16); ++i) {
-		printf("%04hX", (uint32_t)utf16[i]);
-	}
-
-	/*printf("\nConverted UTF8 Bytes:\n");
-	for (size_t i = 0; i < elementsof(utf32); ++i) {
-		printf("%08X", utf32_out[i]);
-	}
-
-	printf("\nCorrect UTF32 Bytes:\n");
-	for (size_t i = 0; i < elementsof(utf32); ++i) {
-		printf("%08X", utf32[i]);
-	}*/
-
-
-	//WCHAR_T_DEC(utf8_in);
-	//WCHAR_T_CONV(utf8_in);
-	/*printf("WChar Output Bytes:\n");
-	for (size_t i = 0; i < elementsof(utf16); ++i) {
-		printf("%04hX", utf8_in_w[i]);
-	}*/
-	//WCHAR_T_FREE(utf8_in);
-	EXPECT_TRUE(
-		!wcscmp((wchar_t*)utf16, (wchar_t*)utf16_out_masking) &&
-		!wcscmp((wchar_t*)utf16, (wchar_t*)utf16_out_bit_scan)
-	);
-}
-
 TEST(Win32Utf8Test, GetModuleHandleEx)
 {
 	if (GetACP() == CP_UTF8) {


### PR DESCRIPTION
I am not really sure why 3 different ways were added to convert UTF-8 strings to UTF-16 strings. But out of the ones that were added, masking was always the fastest in all of my experiments. I therefore decided: (on a separate branch cause I didn't want to upset anyone)

1) masking should be the one and only utf8_to_utf16 function 2) a similar function should also be used for UTF-32 3) these functions should be used everywhere, and mbrtoc16 and mbrtoc32
   should be avoided, since these functions are unimplemented in Wine

And the 3rd point is the whole reason I did any of this to begin with.

This would fix the issue where Wine users are unable to have patches that use UTF-16 strings in any of their options fields and would finally allow me to fix hint files in th10

The commit in which the 3 utf8_to_utf16 functions were introduced is https://github.com/thpatch/thcrap/commit/d796da6de2a8bd39ee94899392708d01ed1eae28