### PR TITLE
tasofro: fix th123 preferring th105 spell comments over its own

### DIFF
--- a/thcrap_tasofro/src/nsml.cpp
+++ b/thcrap_tasofro/src/nsml.cpp
@@ -120,7 +120,7 @@ int nsml_init()
 		char *spellcomments_th123 = fn_for_game("spellcomments.js");
 		jsonvfs_add_map(pattern_spell, { spells_th123, "th105/spells.js"});
 		jsonvfs_add_map(pattern_story, { spells_th123, "th105/spells.js" });
-		jsonvfs_add(pattern_spell, { "th105/spellcomments.js", spellcomments_th123 }, th105_spellcomment_generator);
+		jsonvfs_add(pattern_spell, { spellcomments_th123, "th105/spellcomments.js" }, th105_spellcomment_generator);
 		SAFE_FREE(pattern_spell);
 		SAFE_FREE(pattern_story);
 		SAFE_FREE(spells_th123);


### PR DESCRIPTION
Right now, if there are duplicate keys for spell comments between TH123 and TH105,
it will show the comments of TH105. This small change will make it so the ones for
TH123 are shown and only use TH105 comments as a fallback.

(This mainly affects the common cards as I think character cards don't actually overlap)