### PR TITLE
Add search cue banner and reset functionality to filter

### DIFF
--- a/thcrap_configure_v3/Page2_advanced.xaml
+++ b/thcrap_configure_v3/Page2_advanced.xaml
@@ -21,10 +21,17 @@
                         <ColumnDefinition Width="*" />
                         <ColumnDefinition Width="Auto" />
                     </Grid.ColumnDefinitions>
+
                     <TextBox
                         Name="QuickFilterTextBox"
                         Grid.Column="0"
-                        TextChanged="QuickFilterChanged"/>
+                        Margin="0"
+                        VerticalAlignment="Stretch"
+                        HorizontalAlignment="Stretch"
+                        Padding="0"
+                        BorderThickness="1,1,0,1"
+                        TextChanged="QuickFilterChanged" />
+
                     <TextBlock
                         Name="Placeholder"
                         Text="Search here…"
@@ -32,12 +39,35 @@
                         Margin="5,1,0,0"
                         IsHitTestVisible="False"
                         FontStyle="Italic"
-                        Foreground="Gray"/>
+                        Foreground="{DynamicResource {x:Static SystemColors.GrayTextBrushKey}}"/>
+
                     <Button Name="SearchButton"
                             Grid.Column="1"
-                            Width="20px"
+                            Width="20"
+                            Height="{Binding RelativeSource={RelativeSource Mode=FindAncestor,
+                                AncestorType={x:Type Grid}},
+                                Path=ActualHeight}"
                             Background="Transparent"
-                            Click="SearchButton_OnClick">🔎</Button>
+                            BorderThickness="0,1,1,1"
+                            Padding="0"
+                            Margin="0"
+                            VerticalAlignment="Stretch"
+                            Click="SearchButton_OnClick">
+                        🔎
+                        <Button.Style>
+                            <Style TargetType="Button">
+                                <Setter Property="BorderBrush" Value="{DynamicResource {x:Static SystemColors.ControlDarkBrushKey}}"/>
+                                <Style.Triggers>
+                                    <!-- Trigger to watch the TextBox's IsKeyboardFocusWithin state -->
+                                    <DataTrigger Binding="{Binding IsKeyboardFocusWithin, ElementName=QuickFilterTextBox}" Value="True">
+                                        <!-- I have no idea which SystemColor is correct, most of them seem to be a different blue -->
+                                        <Setter Property="BorderBrush" Value="DodgerBlue"
+                                        />
+                                    </DataTrigger>
+                                </Style.Triggers>
+                            </Style>
+                        </Button.Style>
+                    </Button>
                 </Grid>
             </DockPanel>
             <TreeView x:Name="AvailablePatches" MouseDoubleClick="AvailablePatchDoubleClick"  Margin="0,7,0,0">

--- a/thcrap_configure_v3/Page2_advanced.xaml
+++ b/thcrap_configure_v3/Page2_advanced.xaml
@@ -23,12 +23,16 @@
                     </Grid.ColumnDefinitions>
                     <TextBox
                         Name="QuickFilterTextBox"
-                        Text="Search here..."
                         Grid.Column="0"
-                        Foreground="Gray"
-                        GotFocus="QuickFilter_OnGotFocus"
-                        LostFocus="QuickFilter_OnLostFocus"
                         TextChanged="QuickFilterChanged"/>
+                    <TextBlock
+                        Name="Placeholder"
+                        Text="Search here…"
+                        Grid.Column="0"
+                        Margin="5,1,0,0"
+                        IsHitTestVisible="False"
+                        FontStyle="Italic"
+                        Foreground="Gray"/>
                     <Button Name="SearchButton"
                             Grid.Column="1"
                             Width="20px"

--- a/thcrap_configure_v3/Page2_advanced.xaml
+++ b/thcrap_configure_v3/Page2_advanced.xaml
@@ -1,10 +1,10 @@
 <UserControl x:Class="thcrap_configure_v3.Page2_advanced"
       xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
       xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-      xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" 
-      xmlns:d="http://schemas.microsoft.com/expression/blend/2008" 
+      xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+      xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
       xmlns:local="clr-namespace:thcrap_configure_v3"
-      mc:Ignorable="d" 
+      mc:Ignorable="d"
       d:DesignHeight="450" d:DesignWidth="800">
 
     <Grid>
@@ -16,8 +16,25 @@
         </Grid.ColumnDefinitions>
         <DockPanel Grid.Column="0">
             <DockPanel DockPanel.Dock="Top">
-                <TextBlock Text="Quick filter: " />
-                <TextBox TextChanged="QuickFilterChanged"/>
+                <Grid>
+                    <Grid.ColumnDefinitions>
+                        <ColumnDefinition Width="*" />
+                        <ColumnDefinition Width="Auto" />
+                    </Grid.ColumnDefinitions>
+                    <TextBox
+                        Name="QuickFilterTextBox"
+                        Text="Search here..."
+                        Grid.Column="0"
+                        Foreground="Gray"
+                        GotFocus="QuickFilter_OnGotFocus"
+                        LostFocus="QuickFilter_OnLostFocus"
+                        TextChanged="QuickFilterChanged"/>
+                    <Button Name="SearchButton"
+                            Grid.Column="1"
+                            Width="20px"
+                            Background="Transparent"
+                            Click="SearchButton_OnClick">🔎</Button>
+                </Grid>
             </DockPanel>
             <TreeView x:Name="AvailablePatches" MouseDoubleClick="AvailablePatchDoubleClick"  Margin="0,7,0,0">
                 <TreeView.Resources>

--- a/thcrap_configure_v3/Page2_advanced.xaml.cs
+++ b/thcrap_configure_v3/Page2_advanced.xaml.cs
@@ -28,8 +28,6 @@ namespace thcrap_configure_v3
         private int isUnedited = 1;
         private int configMaxLength = 0;
 
-        private const string SearchCueBanner = "Search here...";
-
         private void ResetConfigName()
         {
             ConfigName.Text = "";
@@ -314,59 +312,26 @@ If you select multiple patches that all modify the same thing, lower patches wil
             var filter = textbox.Text.ToLower();
 
 
-            if (!filter.Contains(SearchCueBanner.ToLower()))
+            if (filter.Length > 0)
             {
-                if (AvailablePatches?.ItemsSource is IEnumerable<Repo> repos)
-                {
-                    foreach (Repo repo in repos)
-                        repo.SetVisibility(repo.UpdateFilter(filter));
-                }
-            }
-
-            if (filter.Contains(SearchCueBanner.ToLower()) && textbox.Text.Length > SearchCueBanner.Length)
-            {
-                textbox.Text = textbox.Text.Replace(SearchCueBanner, string.Empty);
-                textbox.Foreground = new SolidColorBrush(Colors.Black);
-                textbox.CaretIndex = textbox.Text.Length;
+                Placeholder.Visibility = Visibility.Hidden;
                 SearchButton.Content = '\u274c'; // cross mark
             }
-            else if (filter.Length == 0)
+            else
             {
-                textbox.Text = SearchCueBanner;
-                textbox.Foreground = new SolidColorBrush(Colors.Gray);
-                textbox.CaretIndex = 0;
+                Placeholder.Visibility = Visibility.Visible;
                 SearchButton.Content = "\ud83d\udd0e"; // magnifying glass
             }
-        }
-
-        private void QuickFilter_OnGotFocus(object sender, RoutedEventArgs e)
-        {
-            if (sender is TextBox textBox && textBox.Text.Contains(SearchCueBanner))
+            if (AvailablePatches?.ItemsSource is IEnumerable<Repo> repos)
             {
-                textBox.Text = textBox.Text.Replace(SearchCueBanner, string.Empty);
-                textBox.Foreground = new SolidColorBrush(Colors.Black);
-                // SearchButton.Content = '\u274c'; // cross mark
+                foreach (Repo repo in repos)
+                    repo.SetVisibility(repo.UpdateFilter(filter));
             }
-
-        }
-
-        private void QuickFilter_OnLostFocus(object sender, RoutedEventArgs e)
-        {
-            if (sender is TextBox textBox && string.IsNullOrWhiteSpace(textBox.Text))
-            {
-                textBox.Text = SearchCueBanner;
-                textBox.Foreground = new SolidColorBrush(Colors.Gray);
-                // SearchButton.Content = "\ud83d\udd0e"; // magnifying glass
-            }
-
         }
 
         private void SearchButton_OnClick(object sender, RoutedEventArgs e)
         {
-            if (QuickFilterTextBox.Text.Contains(SearchCueBanner)) return;
-            QuickFilterTextBox.Text = SearchCueBanner;
-            QuickFilterTextBox.Foreground = new SolidColorBrush(Colors.Gray);
-            SearchButton.Content = "\ud83d\udd0e"; // magnifying glass
+            QuickFilterTextBox.Text = "";
             QuickFilterTextBox.Focus();
         }
     }


### PR DESCRIPTION
Implemented a placeholder text ("Search here...") and reset logic for the quick filter. The filter now dynamically updates the text color and button icon based on focus and input.

Fixes #275 