### PR TITLE
configure_v3: Toggleable automatic updates button

### DIFF
--- a/thcrap_configure_v3/DownloadPage.xaml
+++ b/thcrap_configure_v3/DownloadPage.xaml
@@ -5,7 +5,7 @@
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008" 
              xmlns:local="clr-namespace:thcrap_configure_v3"
              mc:Ignorable="d" 
-             d:DesignHeight="450" d:DesignWidth="800">
+             d:DesignHeight="460" d:DesignWidth="800">
     <StackPanel>
         <TextBlock Text="Please wait..." />
         <TextBlock Name="Status" />

--- a/thcrap_configure_v3/MainWindow.xaml
+++ b/thcrap_configure_v3/MainWindow.xaml
@@ -6,7 +6,7 @@
         xmlns:xctk="http://schemas.xceed.com/wpf/xaml/toolkit"
         xmlns:local="clr-namespace:thcrap_configure_v3"
         mc:Ignorable="d"
-        Title="Thcrap configuration tool" Height="450" Width="800"
+        Title="Thcrap configuration tool" Height="460" Width="800"
         Loaded="Window_Loaded">
     <xctk:Wizard Name="wizard"
                  FinishButtonClosesWindow="True"

--- a/thcrap_configure_v3/Page2.xaml
+++ b/thcrap_configure_v3/Page2.xaml
@@ -10,8 +10,8 @@
 	<DockPanel>
 		<TextBlock x:Name="warnMessage" DockPanel.Dock="Bottom"
                    Margin="0" Foreground="Red"
-                   Text="WARNING: Automatic updates are turned OFF. You will NOT receive new patches."
-                   Visibility="Collapsed" FontWeight="Bold"/>
+                   Text="WARNING: Automatic updates are turned OFF. Existing patches may be missing some files required for them to work."
+                   Visibility="Collapsed" FontWeight="Bold" TextWrapping="Wrap"/>
 
 		<TabControl SelectionChanged="TabChanged">
 			<TabItem Header="Language patches">

--- a/thcrap_configure_v3/Page2.xaml
+++ b/thcrap_configure_v3/Page2.xaml
@@ -1,17 +1,25 @@
 <UserControl x:Class="thcrap_configure_v3.Page2"
              xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" 
-             xmlns:d="http://schemas.microsoft.com/expression/blend/2008" 
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
              xmlns:local="clr-namespace:thcrap_configure_v3"
-             mc:Ignorable="d" 
-             d:DesignHeight="450" d:DesignWidth="800">
-    <TabControl SelectionChanged="TabChanged">
-        <TabItem Header="Language patches">
-            <local:Page2_simple x:Name="Simple" Margin="6" />
-        </TabItem>
-        <TabItem Header="All patches" Name="tab_AllPatches">
-            <local:Page2_advanced x:Name="Advanced" Margin="6" />
-        </TabItem>
-    </TabControl>
+             mc:Ignorable="d"
+             d:DesignHeight="460" d:DesignWidth="800">
+
+	<DockPanel>
+		<TextBlock x:Name="warnMessage" DockPanel.Dock="Bottom"
+                   Margin="0" Foreground="Red"
+                   Text="WARNING: Automatic updates are turned OFF. You will NOT receive new patches."
+                   Visibility="Collapsed" FontWeight="Bold"/>
+
+		<TabControl SelectionChanged="TabChanged">
+			<TabItem Header="Language patches">
+				<local:Page2_simple x:Name="Simple" Margin="6" />
+			</TabItem>
+			<TabItem Header="All patches" Name="tab_AllPatches">
+				<local:Page2_advanced x:Name="Advanced" Margin="6" />
+			</TabItem>
+		</TabControl>
+	</DockPanel>
 </UserControl>

--- a/thcrap_configure_v3/Page2.xaml.cs
+++ b/thcrap_configure_v3/Page2.xaml.cs
@@ -12,6 +12,7 @@ using System.Windows.Media;
 using System.Windows.Media.Imaging;
 using System.Windows.Navigation;
 using System.Windows.Shapes;
+using System.IO;
 
 namespace thcrap_configure_v3
 {
@@ -31,6 +32,18 @@ namespace thcrap_configure_v3
         public Page2()
         {
             InitializeComponent();
+            this.Loaded += Page2_Loaded;
+        }
+
+        private void Page2_Loaded(object sender, RoutedEventArgs e)
+        {
+            toggleWarning();
+        }
+
+        public void toggleWarning()
+        {
+            bool updatesEnabled = File.Exists("bin\\thcrap_update.dll");
+            warnMessage.Visibility = updatesEnabled ? Visibility.Collapsed : Visibility.Visible;
         }
 
         public void SetRepoList(List<Repo> repoList)

--- a/thcrap_configure_v3/Page2.xaml.cs
+++ b/thcrap_configure_v3/Page2.xaml.cs
@@ -42,7 +42,7 @@ namespace thcrap_configure_v3
 
         public void toggleWarning()
         {
-            bool updatesEnabled = File.Exists("bin\\thcrap_update.dll");
+            bool updatesEnabled = File.Exists($"bin\\thcrap_update{ThcrapDll.DEBUG_OR_RELEASE}.dll");
             warnMessage.Visibility = updatesEnabled ? Visibility.Collapsed : Visibility.Visible;
         }
 

--- a/thcrap_configure_v3/Page2_advanced.xaml
+++ b/thcrap_configure_v3/Page2_advanced.xaml
@@ -5,7 +5,7 @@
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
              xmlns:local="clr-namespace:thcrap_configure_v3"
              mc:Ignorable="d"
-             d:DesignHeight="450" d:DesignWidth="800"
+             d:DesignHeight="460" d:DesignWidth="800"
              UseLayoutRounding="True">
 
     <UserControl.Resources>

--- a/thcrap_configure_v3/Page2_simple.xaml
+++ b/thcrap_configure_v3/Page2_simple.xaml
@@ -19,7 +19,7 @@
         </ItemsControl>
         <RadioButton x:Name="AllLanguagesRadio" GroupName="patch">
             <StackPanel Orientation="Horizontal">
-                <TextBlock Margin="0,0,0,0">Other language:</TextBlock>
+                <TextBlock Margin="0,0,7,0">Other language:</TextBlock>
                 <ComboBox x:Name="AllLanguages" SelectionChanged="AllLanguages_SelectionChanged">
                     <ComboBox.ItemTemplate>
                         <DataTemplate>

--- a/thcrap_configure_v3/Page2_simple.xaml
+++ b/thcrap_configure_v3/Page2_simple.xaml
@@ -6,7 +6,7 @@
              xmlns:xctk="http://schemas.xceed.com/wpf/xaml/toolkit"
              xmlns:local="clr-namespace:thcrap_configure_v3"
              mc:Ignorable="d" 
-             d:DesignHeight="450" d:DesignWidth="800">
+             d:DesignHeight="460" d:DesignWidth="800">
     <StackPanel>
         <ItemsControl x:Name="UserLanguagePatches">
             <ItemsControl.ItemTemplate>
@@ -19,7 +19,7 @@
         </ItemsControl>
         <RadioButton x:Name="AllLanguagesRadio" GroupName="patch">
             <StackPanel Orientation="Horizontal">
-                <TextBlock Margin="0,0,7,0">Other language:</TextBlock>
+                <TextBlock Margin="0,0,0,0">Other language:</TextBlock>
                 <ComboBox x:Name="AllLanguages" SelectionChanged="AllLanguages_SelectionChanged">
                     <ComboBox.ItemTemplate>
                         <DataTemplate>

--- a/thcrap_configure_v3/Page4.xaml
+++ b/thcrap_configure_v3/Page4.xaml
@@ -6,7 +6,7 @@
              xmlns:behaviors="http://schemas.microsoft.com/xaml/behaviors"
              xmlns:local="clr-namespace:thcrap_configure_v3"
              mc:Ignorable="d"
-             d:DesignHeight="450" d:DesignWidth="800">
+             d:DesignHeight="460" d:DesignWidth="800">
     <DockPanel>
         <TextBlock x:Name="AddGamesNotice" DockPanel.Dock="Top" Margin="0,0,0,7">Now, it's time to add games</TextBlock>
         <Grid DockPanel.Dock="Bottom" Margin="0,7,0,0">

--- a/thcrap_configure_v3/Page5.xaml
+++ b/thcrap_configure_v3/Page5.xaml
@@ -5,7 +5,7 @@
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008" 
              xmlns:local="clr-namespace:thcrap_configure_v3"
              mc:Ignorable="d" 
-             d:DesignHeight="450" d:DesignWidth="800">
+             d:DesignHeight="460" d:DesignWidth="800">
     <StackPanel>
         <TextBlock>Create shortcuts:</TextBlock>
         <CheckBox Margin="0,7,0,0" Checked="checkbox_Checked" Unchecked="checkbox_Checked" x:Name="checkboxDesktop" IsChecked="True">On your desktop</CheckBox>

--- a/thcrap_configure_v3/Runconfig.cs
+++ b/thcrap_configure_v3/Runconfig.cs
@@ -57,6 +57,7 @@ namespace thcrap_configure_v3
             return instance;
         }
 
+        public bool auto_updates         { get; set; }
         public bool background_updates   { get; set; }
         public long time_between_updates { get; set; }
         public bool update_at_exit       { get; set; }

--- a/thcrap_configure_v3/SettingsWindow.xaml
+++ b/thcrap_configure_v3/SettingsWindow.xaml
@@ -11,6 +11,7 @@
         <StackPanel>
             <StackPanel>
                 <Label Content="Updating"/>
+				<CheckBox Name="auto_updates" Content="Toggle automatic updates" Checked="AutoUpdates_Checked" Unchecked="AutoUpdates_Unchecked"/>
                 <CheckBox Name="background_updates" Content="Enable background updates when a game is running" Checked="BackgroundUpdates_Checked" Unchecked="BackgroundUpdates_Unchecked"/>
                 <CheckBox Name="update_at_exit" Content="Update game files after the game exits"/>
                 <CheckBox Name="update_others" Content="Update other games" IsEnabled="False"/>

--- a/thcrap_configure_v3/SettingsWindow.xaml
+++ b/thcrap_configure_v3/SettingsWindow.xaml
@@ -5,13 +5,13 @@
         xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
         xmlns:local="clr-namespace:thcrap_configure_v3"
         mc:Ignorable="d"
-        Title="thcrap Settings" Height="450" Width="800"
+        Title="thcrap Settings" Height="460" Width="800"
         Loaded="WindowOpened">
     <Grid Margin="10,0,0,0">
         <StackPanel>
             <StackPanel>
                 <Label Content="Updating"/>
-				<CheckBox Name="auto_updates" Content="Toggle automatic updates" Checked="AutoUpdates_Checked" Unchecked="AutoUpdates_Unchecked"/>
+				<CheckBox Name="auto_updates" Content="Toggle automatic updates"/>
                 <CheckBox Name="background_updates" Content="Enable background updates when a game is running" Checked="BackgroundUpdates_Checked" Unchecked="BackgroundUpdates_Unchecked"/>
                 <CheckBox Name="update_at_exit" Content="Update game files after the game exits"/>
                 <CheckBox Name="update_others" Content="Update other games" IsEnabled="False"/>

--- a/thcrap_configure_v3/SettingsWindow.xaml.cs
+++ b/thcrap_configure_v3/SettingsWindow.xaml.cs
@@ -1,4 +1,5 @@
 using System;
+using System.IO;
 using System.Text.RegularExpressions;
 using System.Windows;
 using System.Windows.Controls;
@@ -18,6 +19,7 @@ namespace thcrap_configure_v3
         void WindowOpened(object sender, RoutedEventArgs e)
         {
             GlobalConfig config = GlobalConfig.get();
+            auto_updates.IsChecked = File.Exists("bin\\thcrap_update.dll");
             background_updates.IsChecked = config.background_updates;
             update_others.IsChecked = config.update_others;
             update_at_exit.IsChecked = config.update_at_exit;
@@ -94,6 +96,32 @@ namespace thcrap_configure_v3
         {
             e.Handled = NumbersOnlyRegex.IsMatch(e.Text);
         }
+
+        void AutoUpdates_Checked(object sender, RoutedEventArgs e)
+        {
+            UpdateDLL("bin\\thcrap_update_disabled.dll", "bin\\thcrap_update.dll");
+        }
+
+        void AutoUpdates_Unchecked(object sender, RoutedEventArgs e)
+        {
+            UpdateDLL("bin\\thcrap_update.dll", "bin\\thcrap_update_disabled.dll");
+        }
+
+        private void UpdateDLL(string source, string destination)
+        {
+            try
+            {
+                if (File.Exists(source))
+                {
+                    File.Move(source, destination);
+                }
+            }
+            catch (Exception ex)
+            {
+                MessageBox.Show("Failed to toggle automatic updates:\n" + ex.Message, "Error", MessageBoxButton.OK, MessageBoxImage.Error);
+            }
+        }
+
         void BackgroundUpdates_Checked(object sender, RoutedEventArgs e)
         {
             update_others.IsEnabled = true;

--- a/thcrap_configure_v3/SettingsWindow.xaml.cs
+++ b/thcrap_configure_v3/SettingsWindow.xaml.cs
@@ -11,8 +11,8 @@ namespace thcrap_configure_v3
     {
         public MainWindow mainWindow;
         public bool isClosedWithX = true;
-        private string updateDLL = "bin\\thcrap_update.dll";
-        private string updateDLLDisabled = "bin\\thcrap_update_disabled.dll";
+        private string updateDLL = $"bin\\thcrap_update{ThcrapDll.DEBUG_OR_RELEASE}.dll";
+        private string updateDLLDisabled = $"bin\\thcrap_update{ThcrapDll.DEBUG_OR_RELEASE}_disabled.dll";
         private bool autoUpdateChoice;
         public SettingsWindow()
         {
@@ -40,7 +40,6 @@ namespace thcrap_configure_v3
                 try
                 {
                     File.Delete(updateDLLDisabled);
-                    ThcrapDll.globalconfig_set_boolean("auto_updates", true);
                 }
                 catch { }
             }


### PR DESCRIPTION
Added an option in the config menu in configure_v3 to enable/disable automatic updates,
which renames the update DLL in /bin/, which is also fetched when the config menu is opened for the default checkbox state.