### PR TITLE
Hide username in logs #241

### DIFF
--- a/thcrap/src/log.cpp
+++ b/thcrap/src/log.cpp
@@ -149,7 +149,7 @@ static bool is_drive_letter(char c) {
 //Returns the index of the end of the username or, if no match was detected, 0
 static uint32_t get_end_username(const char* str, uint32_t n, int iterator) {
 	
-	if (iterator + 8 > n) {
+	if (iterator + 8 > n) {  //iterator + 1 = :, i + 8 is the character after the final '\' in :'\'Users'\'
 		return 0;
 	}
 
@@ -182,7 +182,7 @@ static uint32_t get_end_username(const char* str, uint32_t n, int iterator) {
 			delete[] beginning;
 			return iterator + i;
 		}
-		else { //iterator + 1 = :, i + 8 is the character after the final '\' in :'\'Users'\'
+		else {
 			delete[] beginning;
 			return 0;
 		}
@@ -194,7 +194,7 @@ static uint32_t get_end_username(const char* str, uint32_t n, int iterator) {
 
 }
 
-// Uses malloc to copy a string, requires free
+// Uses malloc to copy a string
 static char* duplicate_str(const char* str, uint32_t n) {
 	char* new_str = (char*)malloc(n + 1);
 	new_str[n] = '\0';
@@ -209,7 +209,7 @@ static char* strip_username_from_path(const char* str, uint32_t n) {
 	uint32_t current_strlen = n;
 	while (iterator + minimum_capture_len < current_strlen) {
 
-		if (is_drive_letter(return_str[iterator]) && return_str[iterator + 1] == ':') { /* D: will be contiguous but I'm not certain about D:\Users since the '\' character could instead be Yen or Won character which is utf-8  */
+		if (is_drive_letter(return_str[iterator]) && return_str[iterator + 1] == ':') {
 			uint32_t end_username = get_end_username(return_str, current_strlen, iterator);
 			if (end_username > 0) {
 				uint32_t replacement_len = strlen("%userprofile%");

--- a/thcrap/src/log.h
+++ b/thcrap/src/log.h
@@ -34,6 +34,8 @@ THCRAP_API void log_nprint(const char *text, size_t n);
 // Formatted
 THCRAP_API void log_vprintf(const char *format, va_list va);
 THCRAP_API void log_printf(const char *format, ...);
+THCRAP_API char* prefilter_log(const char* str, uint32_t n);
+
 #ifdef NDEBUG
 // Using __noop makes the compiler check the validity of the
 // macro contents for syntax errors without actually compiling them.

--- a/thcrap_test/log_tests.cpp
+++ b/thcrap_test/log_tests.cpp
@@ -19,7 +19,12 @@ TEST(log_tests, verify_filters) {
 	test_logs("C:\\Users\\霧雨　魔理沙\\ Starting", "%userprofile%\\ Starting"); //Starting Match
 	test_logs("Middle C:\\Users\\霧雨　魔理沙\\ End", "Middle %userprofile%\\ End"); //Middle Match
 	test_logs("Opening Text: C:\\Users\\霧雨　魔理沙\\Games\\th07.exe End", "Opening Text: %userprofile%\\Games\\th07.exe End"); //Complete Path
-	test_logs("Opening Text: C:\\Users\\霧雨　魔理沙\\Games\\th07.exe Middle Text: C:\\Users\\Hakurei Reimu\\Games\\th06.exe End", "Opening Text: %userprofile%\\Games\\th07.exe Middle Text: %userprofile%\\Games\\th06.exe End"); //Double Match
-	test_logs("Opening Text:\\Users D:\\User\\NotTheUsersFolder C:\\Users\\霧雨　魔理沙\\Games\\th07.exe Middle Text", "Opening Text:\\Users D:\\User\\NotTheUsersFolder %userprofile%\\Games\\th07.exe Middle Text"); //Intentionally obfuscated Match
-
+	test_logs("Opening Text: C:\\Users\\霧雨　魔理沙\\Games\\th07.exe Middle Text: C:\\Users\\Hakurei Reimu\\Games\\th06.exe End",
+		"Opening Text: %userprofile%\\Games\\th07.exe Middle Text: %userprofile%\\Games\\th06.exe End"); //Double Match
+	test_logs("Opening Text:\\Users D:\\User\\NotTheUsersFolder C:\\Users\\霧雨　魔理沙\\Games\\th07.exe Middle Text",
+		"Opening Text:\\Users D:\\User\\NotTheUsersFolder %userprofile%\\Games\\th07.exe Middle Text"); //Intentionally obfuscated Match
+	test_logs("Opening Text: C:/Users\\霧雨　魔理沙/Games\\th07.exe End", "Opening Text: %userprofile%/Games\\th07.exe End"); //Variable seperators
+	test_logs("Opening Text: C:\\Users/霧雨　魔理沙\\Games\\th07.exe End", "Opening Text: %userprofile%\\Games\\th07.exe End"); //Variable seperators 2
+	test_logs("Opening Text: C:/home/霧雨　魔理沙/Games/th07.exe End", "Opening Text: %userprofile%/Games/th07.exe End"); //Wine
+	test_logs("Opening Text: C:\\Documents and Settings/霧雨　魔理沙\\Games\\th07.exe End", "Opening Text: %userprofile%\\Games\\th07.exe End"); //XP
 }

--- a/thcrap_test/log_tests.cpp
+++ b/thcrap_test/log_tests.cpp
@@ -1,0 +1,25 @@
+#include "thcrap.h"
+#include "gtest/gtest.h"
+
+static void test_logs(const char* str, const char* output) {
+	ASSERT_STREQ(prefilter_log(str, strlen(str)), output);
+}
+
+
+TEST(log_tests, verify_filters) {
+	test_logs("Normal Unmatched String", "Normal Unmatched String");
+	test_logs("C:\\", "C:\\"); //Partial Match
+	test_logs("C:/", "C:/"); //Partial Match Unix
+	test_logs("C:\\Users\\PartialMatch", "C:\\Users\\PartialMatch");
+	test_logs("C:\\Users\\Marisa Kirisame\\", "%userprofile%\\"); //Basic match
+	test_logs("c:\\Users\\Marisa Kirisame\\", "%userprofile%\\"); //Basic match lowercase drive
+	test_logs("C:\\Users\\霧雨　魔理沙\\", "%userprofile%\\"); //Basic match - UTF-8
+	test_logs("D:\\Users\\霧雨　魔理沙\\", "%userprofile%\\"); //Basic match - alternate drive
+	test_logs("Ending C:\\Users\\霧雨　魔理沙\\", "Ending %userprofile%\\"); //Ending Match
+	test_logs("C:\\Users\\霧雨　魔理沙\\ Starting", "%userprofile%\\ Starting"); //Starting Match
+	test_logs("Middle C:\\Users\\霧雨　魔理沙\\ End", "Middle %userprofile%\\ End"); //Middle Match
+	test_logs("Opening Text: C:\\Users\\霧雨　魔理沙\\Games\\th07.exe End", "Opening Text: %userprofile%\\Games\\th07.exe End"); //Complete Path
+	test_logs("Opening Text: C:\\Users\\霧雨　魔理沙\\Games\\th07.exe Middle Text: C:\\Users\\Hakurei Reimu\\Games\\th06.exe End", "Opening Text: %userprofile%\\Games\\th07.exe Middle Text: %userprofile%\\Games\\th06.exe End"); //Double Match
+	test_logs("Opening Text:\\Users D:\\User\\NotTheUsersFolder C:\\Users\\霧雨　魔理沙\\Games\\th07.exe Middle Text", "Opening Text:\\Users D:\\User\\NotTheUsersFolder %userprofile%\\Games\\th07.exe Middle Text"); //Intentionally obfuscated Match
+
+}

--- a/thcrap_test/thcrap_test.vcxproj
+++ b/thcrap_test/thcrap_test.vcxproj
@@ -47,6 +47,7 @@
     <ClCompile Include="$(GoogleTestDir)src\gtest_main.cc">
       <PrecompiledHeader>NotUsing</PrecompiledHeader>
     </ClCompile>
+    <ClCompile Include="log_tests.cpp" />
     <ClCompile Include="src\expression.cpp" />
     <ClCompile Include="src\repo.cpp">
       <PrecompiledHeader>Create</PrecompiledHeader>


### PR DESCRIPTION
Initial commit with tests. Replaces "<DriveLetter>:\Users\<Username>\" with "%userprofile%\". Also applies to '/' seperators.
Aims to solve issue #241

Not sure about adding regex to this project so avoided it. 
Exposed a new function in log.h for testing.
Testing & .h changes could be skipped.