### PR TITLE
Rename `unexpected` to `UNEXPECTED` to prevent clashing with `std::unexpected`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -56,10 +56,6 @@ CFLAGS += -Wno-unused-but-set-variable -Wno-sign-compare
 CXXFLAGS = $(CFLAGS) -std=c++17
 # For rand_s
 CXXFLAGS += -D_CRT_RAND_S
-# std::unexpected, which is removed in C++17, conflicts with our unexpected() macro.
-# This define tells the glibc to remove the deprecated functions.
-# ... until std::unexpected comes back as another thing in C++23.
-CXXFLAGS += -D_GLIBCXX_USE_DEPRECATED=0
 
 LDFLAGS += -o $@ -Lbin/bin -Llibs/external_deps/bin
 

--- a/thcrap/src/binhack.cpp
+++ b/thcrap/src/binhack.cpp
@@ -144,12 +144,12 @@ static TH_NOINLINE const char* consume_float_value(const char *const expr, patch
 	char* expr_next;
 	errno = 0;
 	double result = _strtod_l(expr, &expr_next, lc_neutral.locale);
-	if unexpected(expr == expr_next) {
+	if condition_unlikely(expr == expr_next) {
 		// Not actually a floating-point number, keep going though
 		val->type = PVT_NONE;
 		return expr + 1;
 	}
-	if unexpected(fabs(result) == HUGE_VAL && errno == ERANGE) {
+	if condition_unlikely(fabs(result) == HUGE_VAL && errno == ERANGE) {
 		log_printf("ERROR: Floating point constant \"%.*s\" out of range!\n", expr_next - expr, expr);
 		return NULL;
 	}
@@ -296,7 +296,7 @@ static constexpr size_t patch_val_sizes[] = {
 #pragma warning(disable : 4307 4146)
 void constpool_apply(HackpointMemoryPage* page_array) {
 
-	if unexpected(constpool_prerenders.empty()) {
+	if condition_unlikely(constpool_prerenders.empty()) {
 		return;
 	}
 
@@ -378,7 +378,7 @@ void constpool_apply(HackpointMemoryPage* page_array) {
 					}
 				}
 				element_pos = end_element + 1;
-				if unexpected(filled_value_size + per_element_size >= current_value_alloc_size) {
+				if condition_unlikely(filled_value_size + per_element_size >= current_value_alloc_size) {
 					current_value = (uint8_t*)realloc(current_value, current_value_alloc_size += BINHACK_BUFSIZE_MIN);
 				}
 				switch (per_element_size) {
@@ -581,7 +581,7 @@ void constpool_apply(HackpointMemoryPage* page_array) {
 		}
 		// These are brand new values, so expand the allocation
 		overaligned_value_size = AlignUpToMultipleOf2(aligned_value_size, sizeof(__m128i));
-		if unexpected(constpool_memory_size + overaligned_value_size >= rendered_values_alloc_size) {
+		if condition_unlikely(constpool_memory_size + overaligned_value_size >= rendered_values_alloc_size) {
 			size_t new_alloc_size = rendered_values_alloc_size + overaligned_value_size + BINHACK_BUFSIZE_MIN;
 			rendered_values = (uint8_t*)realloc(rendered_values, new_alloc_size);
 			padding_tracking = (uint8_t*)realloc(padding_tracking, new_alloc_size);
@@ -914,7 +914,7 @@ size_t code_string_calc_size(const char* code_str) {
 		}
 
 		// Check for errors
-		if unexpected(!code_str) {
+		if condition_unlikely(!code_str) {
 			// Code string calc size error
 			return 0;
 		}
@@ -1006,7 +1006,7 @@ int code_string_render(uint8_t* output_buffer, uintptr_t target_addr, const char
 			case '(': // Expression
 				code_str = check_for_code_string_cast(++code_str, &val);
 				code_str = eval_expr(code_str, ')', &val.z, NULL, target_addr, hMod);
-				if unexpected(!code_str) {
+				if condition_unlikely(!code_str) {
 					break; // Error
 				}
 				switch (val.type) {
@@ -1097,7 +1097,7 @@ int code_string_render(uint8_t* output_buffer, uintptr_t target_addr, const char
 		}
 
 		// Check for errors
-		if unexpected(!code_str) {
+		if condition_unlikely(!code_str) {
 			log_print("Code string render error!\n");
 			return CodeStringErrorRet;
 		}
@@ -1198,7 +1198,7 @@ int code_string_render(uint8_t* output_buffer, uintptr_t target_addr, const char
 				break;
 			case PVT_CODE: {
 				while (val.code.count--) {
-					if unexpected(code_string_render(output_buffer, target_addr, val.code.ptr, hMod)) {
+					if condition_unlikely(code_string_render(output_buffer, target_addr, val.code.ptr, hMod)) {
 						return CodeStringErrorRet;
 					}
 					output_buffer += val.code.len;
@@ -1499,7 +1499,7 @@ bool codecave_from_json(const char *name, json_t *in, codecave_t *out) {
 				} else {
 					align_val = 1u;
 				}
-				if unexpected(align_val > 4096) {
+				if condition_unlikely(align_val > 4096) {
 					log_printf("ERROR: invalid alignment specified for codecave %s, must be <=4096\n", name);
 					return false;
 				}
@@ -1637,7 +1637,7 @@ size_t codecaves_apply(codecave_t *codecaves, size_t codecaves_count, HMODULE hM
 
 		// This doesn't make good use of padding bytes
 		size_t align_offset = codecaves_alloc_size[access] & align - 1;
-		if unexpected(align_offset) {
+		if condition_unlikely(align_offset) {
 			align_offset = align - align_offset;
 			codecaves_full_size[last_written_index[access]] += align_offset;
 		}

--- a/thcrap/src/binhack.cpp
+++ b/thcrap/src/binhack.cpp
@@ -144,12 +144,12 @@ static TH_NOINLINE const char* consume_float_value(const char *const expr, patch
 	char* expr_next;
 	errno = 0;
 	double result = _strtod_l(expr, &expr_next, lc_neutral.locale);
-	if condition_unlikely(expr == expr_next) {
+	if UNEXPECTED(expr == expr_next) {
 		// Not actually a floating-point number, keep going though
 		val->type = PVT_NONE;
 		return expr + 1;
 	}
-	if condition_unlikely(fabs(result) == HUGE_VAL && errno == ERANGE) {
+	if UNEXPECTED(fabs(result) == HUGE_VAL && errno == ERANGE) {
 		log_printf("ERROR: Floating point constant \"%.*s\" out of range!\n", expr_next - expr, expr);
 		return NULL;
 	}
@@ -296,7 +296,7 @@ static constexpr size_t patch_val_sizes[] = {
 #pragma warning(disable : 4307 4146)
 void constpool_apply(HackpointMemoryPage* page_array) {
 
-	if condition_unlikely(constpool_prerenders.empty()) {
+	if UNEXPECTED(constpool_prerenders.empty()) {
 		return;
 	}
 
@@ -378,7 +378,7 @@ void constpool_apply(HackpointMemoryPage* page_array) {
 					}
 				}
 				element_pos = end_element + 1;
-				if condition_unlikely(filled_value_size + per_element_size >= current_value_alloc_size) {
+				if UNEXPECTED(filled_value_size + per_element_size >= current_value_alloc_size) {
 					current_value = (uint8_t*)realloc(current_value, current_value_alloc_size += BINHACK_BUFSIZE_MIN);
 				}
 				switch (per_element_size) {
@@ -581,7 +581,7 @@ void constpool_apply(HackpointMemoryPage* page_array) {
 		}
 		// These are brand new values, so expand the allocation
 		overaligned_value_size = AlignUpToMultipleOf2(aligned_value_size, sizeof(__m128i));
-		if condition_unlikely(constpool_memory_size + overaligned_value_size >= rendered_values_alloc_size) {
+		if UNEXPECTED(constpool_memory_size + overaligned_value_size >= rendered_values_alloc_size) {
 			size_t new_alloc_size = rendered_values_alloc_size + overaligned_value_size + BINHACK_BUFSIZE_MIN;
 			rendered_values = (uint8_t*)realloc(rendered_values, new_alloc_size);
 			padding_tracking = (uint8_t*)realloc(padding_tracking, new_alloc_size);
@@ -914,7 +914,7 @@ size_t code_string_calc_size(const char* code_str) {
 		}
 
 		// Check for errors
-		if condition_unlikely(!code_str) {
+		if UNEXPECTED(!code_str) {
 			// Code string calc size error
 			return 0;
 		}
@@ -1006,7 +1006,7 @@ int code_string_render(uint8_t* output_buffer, uintptr_t target_addr, const char
 			case '(': // Expression
 				code_str = check_for_code_string_cast(++code_str, &val);
 				code_str = eval_expr(code_str, ')', &val.z, NULL, target_addr, hMod);
-				if condition_unlikely(!code_str) {
+				if UNEXPECTED(!code_str) {
 					break; // Error
 				}
 				switch (val.type) {
@@ -1097,7 +1097,7 @@ int code_string_render(uint8_t* output_buffer, uintptr_t target_addr, const char
 		}
 
 		// Check for errors
-		if condition_unlikely(!code_str) {
+		if UNEXPECTED(!code_str) {
 			log_print("Code string render error!\n");
 			return CodeStringErrorRet;
 		}
@@ -1198,7 +1198,7 @@ int code_string_render(uint8_t* output_buffer, uintptr_t target_addr, const char
 				break;
 			case PVT_CODE: {
 				while (val.code.count--) {
-					if condition_unlikely(code_string_render(output_buffer, target_addr, val.code.ptr, hMod)) {
+					if UNEXPECTED(code_string_render(output_buffer, target_addr, val.code.ptr, hMod)) {
 						return CodeStringErrorRet;
 					}
 					output_buffer += val.code.len;
@@ -1499,7 +1499,7 @@ bool codecave_from_json(const char *name, json_t *in, codecave_t *out) {
 				} else {
 					align_val = 1u;
 				}
-				if condition_unlikely(align_val > 4096) {
+				if UNEXPECTED(align_val > 4096) {
 					log_printf("ERROR: invalid alignment specified for codecave %s, must be <=4096\n", name);
 					return false;
 				}
@@ -1637,7 +1637,7 @@ size_t codecaves_apply(codecave_t *codecaves, size_t codecaves_count, HMODULE hM
 
 		// This doesn't make good use of padding bytes
 		size_t align_offset = codecaves_alloc_size[access] & align - 1;
-		if condition_unlikely(align_offset) {
+		if UNEXPECTED(align_offset) {
 			align_offset = align - align_offset;
 			codecaves_full_size[last_written_index[access]] += align_offset;
 		}

--- a/thcrap/src/bp_file.cpp
+++ b/thcrap/src/bp_file.cpp
@@ -61,7 +61,7 @@ THREAD_LOCAL(file_rep_t, fr_tls, NULL, file_rep_clear);
 size_t BP_file_buffer(x86_reg_t *regs, json_t *bp_info)
 {
 	file_rep_t *fr = fr_tls_get();
-	if unexpected(fr->disable) {
+	if condition_unlikely(fr->disable) {
 		return 1;
 	}
 
@@ -78,7 +78,7 @@ size_t BP_file_buffer(x86_reg_t *regs, json_t *bp_info)
 size_t BP_file_load(x86_reg_t *regs, json_t *bp_info)
 {
 	file_rep_t *fr = fr_tls_get();
-	if unexpected(fr->disable) {
+	if condition_unlikely(fr->disable) {
 		return 1;
 	}
 
@@ -139,7 +139,7 @@ size_t BP_file_load(x86_reg_t *regs, json_t *bp_info)
 // Cool function name.
 int DumpDatFile(const char *dir, const char *name, const void *buffer, size_t size, bool overwrite_existing)
 {
-	if unexpected(!buffer || !name) {
+	if condition_unlikely(!buffer || !name) {
 		return -1;
 	}
 
@@ -155,7 +155,7 @@ int DumpDatFile(const char *dir, const char *name, const void *buffer, size_t si
 size_t BP_file_loaded(x86_reg_t *regs, json_t *bp_info)
 {
 	file_rep_t *fr = fr_tls_get();
-	if unexpected(fr->disable) {
+	if condition_unlikely(fr->disable) {
 		return 1;
 	}
 

--- a/thcrap/src/bp_file.cpp
+++ b/thcrap/src/bp_file.cpp
@@ -61,7 +61,7 @@ THREAD_LOCAL(file_rep_t, fr_tls, NULL, file_rep_clear);
 size_t BP_file_buffer(x86_reg_t *regs, json_t *bp_info)
 {
 	file_rep_t *fr = fr_tls_get();
-	if condition_unlikely(fr->disable) {
+	if UNEXPECTED(fr->disable) {
 		return 1;
 	}
 
@@ -78,7 +78,7 @@ size_t BP_file_buffer(x86_reg_t *regs, json_t *bp_info)
 size_t BP_file_load(x86_reg_t *regs, json_t *bp_info)
 {
 	file_rep_t *fr = fr_tls_get();
-	if condition_unlikely(fr->disable) {
+	if UNEXPECTED(fr->disable) {
 		return 1;
 	}
 
@@ -139,7 +139,7 @@ size_t BP_file_load(x86_reg_t *regs, json_t *bp_info)
 // Cool function name.
 int DumpDatFile(const char *dir, const char *name, const void *buffer, size_t size, bool overwrite_existing)
 {
-	if condition_unlikely(!buffer || !name) {
+	if UNEXPECTED(!buffer || !name) {
 		return -1;
 	}
 
@@ -155,7 +155,7 @@ int DumpDatFile(const char *dir, const char *name, const void *buffer, size_t si
 size_t BP_file_loaded(x86_reg_t *regs, json_t *bp_info)
 {
 	file_rep_t *fr = fr_tls_get();
-	if condition_unlikely(fr->disable) {
+	if UNEXPECTED(fr->disable) {
 		return 1;
 	}
 

--- a/thcrap/src/breakpoint.cpp
+++ b/thcrap/src/breakpoint.cpp
@@ -90,7 +90,7 @@ patch_val_t json_typed_value(json_t *val, x86_reg_t *regs, patch_value_type_t ty
 	patch_val_t ret;
 
 	void* value = json_pointer_value(val, regs);
-	if unexpected(!value) {
+	if condition_unlikely(!value) {
 		ret.type = PVT_UNKNOWN;
 		return ret;
 	}

--- a/thcrap/src/breakpoint.cpp
+++ b/thcrap/src/breakpoint.cpp
@@ -90,7 +90,7 @@ patch_val_t json_typed_value(json_t *val, x86_reg_t *regs, patch_value_type_t ty
 	patch_val_t ret;
 
 	void* value = json_pointer_value(val, regs);
-	if condition_unlikely(!value) {
+	if UNEXPECTED(!value) {
 		ret.type = PVT_UNKNOWN;
 		return ret;
 	}

--- a/thcrap/src/dialog.cpp
+++ b/thcrap/src/dialog.cpp
@@ -233,7 +233,7 @@ void dialog_adjust_init(
 	const DLGTEMPLATEEX_FONT *dst_font
 )
 {
-	if unexpected(!adj || !dst_header || !dst_font) {
+	if UNEXPECTED(!adj || !dst_header || !dst_font) {
 		return;
 	}
 	ZeroMemory(adj, sizeof(*adj));
@@ -266,7 +266,7 @@ void dialog_adjust(
 	const stringref_t rep
 )
 {
-	if unexpected(!adj || !adj->hDC || !item || !rep.data()) {
+	if UNEXPECTED(!adj || !adj->hDC || !item || !rep.data()) {
 		return;
 	}
 	RECT rect = { 0, 0, item->cx, 0 };
@@ -302,7 +302,7 @@ void dialog_adjust(
 
 void dialog_adjust_clear(dialog_adjust_t *adj)
 {
-	if unexpected(!adj) {
+	if UNEXPECTED(!adj) {
 		return;
 	}
 	DeleteObject(adj->hFont);
@@ -459,7 +459,7 @@ DLGTEMPLATE* dialog_translate_internal(LPCSTR lpTemplateName, HGLOBAL hDlg, size
 	const char *dlg_format = NULL;
 	HGLOBAL hDlg_rep = NULL;
 
-	if unexpected(!lpTemplateName || !hDlg) {
+	if UNEXPECTED(!lpTemplateName || !hDlg) {
 		return NULL;
 	}
 
@@ -533,14 +533,14 @@ DLGTEMPLATE* dialog_translate(HINSTANCE hInstance, LPCSTR lpTemplateName)
 	HGLOBAL hDlg = NULL;
 	size_t hDlg_len;
 
-	if unexpected(!lpTemplateName) {
+	if UNEXPECTED(!lpTemplateName) {
 		return NULL;
 	}
 
 	// MAKEINTRESOURCE(5) == RT_DIALOG.
 	hrsrc = FindResourceA(hInstance, lpTemplateName, MAKEINTRESOURCEA(5));
 	hDlg = LoadResource(hInstance, hrsrc);
-	if unexpected(!hDlg) {
+	if UNEXPECTED(!hDlg) {
 		return NULL;
 	}
 
@@ -556,14 +556,14 @@ DLGTEMPLATE* dialog_translatew(HINSTANCE hInstance, LPCWSTR lpTemplateName)
 	size_t hDlg_len;
 	DLGTEMPLATE *dlg_out = NULL;
 
-	if unexpected(!lpTemplateName) {
+	if UNEXPECTED(!lpTemplateName) {
 		return NULL;
 	}
 
 	// MAKEINTRESOURCE(5) == RT_DIALOG.
 	hrsrc = FindResourceW(hInstance, lpTemplateName, MAKEINTRESOURCEW(5));
 	hDlg = LoadResource(hInstance, hrsrc);
-	if unexpected(!hDlg) {
+	if UNEXPECTED(!hDlg) {
 		return NULL;
 	}
 

--- a/thcrap/src/exception.cpp
+++ b/thcrap/src/exception.cpp
@@ -264,7 +264,7 @@ parsed_prefix:
 			branch_target = addr + 1 + *(int8_t*)addr;
 		print_branch:
 			log_print("\nOpcode: ");
-			if unexpected(rep_type == 1) log_print("BND ");
+			if condition_unlikely(rep_type == 1) log_print("BND ");
 			switch (segment) {
 				case -1: case 0: case 2: case 5: break;
 				case 1: log_print("-"); break; // Not taken hint
@@ -383,7 +383,7 @@ parsed_prefix:
 			TH_UNREACHABLE;
 		case 0xE8: case 0xE9: // JMP, CALL
 			log_print("\nOpcode: ");
-			if unexpected(rep_type == 1) log_print("BND ");
+			if condition_unlikely(rep_type == 1) log_print("BND ");
 			if (DATASIZE_NOT_16) {
 				branch_target = addr + 4 + *(int32_t*)addr;
 				log_printf(
@@ -440,8 +440,8 @@ parsed_prefix:
 					goto unrecognized_opcode;
 				case 2: // CALL rm
 					log_print("\nOpcode: ");
-					if unexpected(rep_type == 1) log_print("BND ");
-					if unexpected(segment == 3) log_print("NOTRACK ");
+					if condition_unlikely(rep_type == 1) log_print("BND ");
+					if condition_unlikely(segment == 3) log_print("NOTRACK ");
 					log_print("CALL ");
 				print_indirect:
 					mod = opcode >> 6;
@@ -617,7 +617,7 @@ parsed_prefix:
 #ifdef TH_X64
 								case 6: // Relative addr
 									final_addr = addr + 4 + offset;
-									if unexpected(addrsize) final_addr = (uint32_t)final_addr;
+									if condition_unlikely(addrsize) final_addr = (uint32_t)final_addr;
 									if (offset >= 0) {
 										log_printf(
 											!addrsize ? "RIP + 0x%X] (0x%p)" : "EIP + 0x%X] (0x%08X)"
@@ -769,8 +769,8 @@ parsed_prefix:
 					TH_UNREACHABLE;
 				case 4: // JMP rm
 					log_print("\nOpcode: ");
-					if unexpected(rep_type == 1) log_print("BND ");
-					if unexpected(segment == 3) log_print("NOTRACK ");
+					if condition_unlikely(rep_type == 1) log_print("BND ");
+					if condition_unlikely(segment == 3) log_print("NOTRACK ");
 					log_print("JMP ");
 					goto print_indirect;
 				case 5: // JMP FAR m
@@ -820,7 +820,7 @@ static void log_print_context(CONTEXT* ctx)
 			);
 #endif
 		}
-		if unexpected(last_branch_logging) {
+		if condition_unlikely(last_branch_logging) {
 #ifdef TH_X64
 			uintptr_t exception_from = ctx->LastExceptionFromRip;
 #else
@@ -1187,7 +1187,7 @@ TH_CALLER_FREE static char* get_windows_error_message(DWORD ExceptionCode) {
 	HGLOBAL resource_handle = LoadResource(ntdll_handle, resource_info_handle);
 
 	MESSAGE_RESOURCE_DATA* resource_pointer = (MESSAGE_RESOURCE_DATA*)LockResource(resource_handle);
-	if unexpected(resource_pointer == NULL) {
+	if condition_unlikely(resource_pointer == NULL) {
 		// TODO Figure out why Wine isn't finding the message table resource in ntdll
 		return NULL;
 	}

--- a/thcrap/src/exception.cpp
+++ b/thcrap/src/exception.cpp
@@ -264,7 +264,7 @@ parsed_prefix:
 			branch_target = addr + 1 + *(int8_t*)addr;
 		print_branch:
 			log_print("\nOpcode: ");
-			if condition_unlikely(rep_type == 1) log_print("BND ");
+			if UNEXPECTED(rep_type == 1) log_print("BND ");
 			switch (segment) {
 				case -1: case 0: case 2: case 5: break;
 				case 1: log_print("-"); break; // Not taken hint
@@ -383,7 +383,7 @@ parsed_prefix:
 			TH_UNREACHABLE;
 		case 0xE8: case 0xE9: // JMP, CALL
 			log_print("\nOpcode: ");
-			if condition_unlikely(rep_type == 1) log_print("BND ");
+			if UNEXPECTED(rep_type == 1) log_print("BND ");
 			if (DATASIZE_NOT_16) {
 				branch_target = addr + 4 + *(int32_t*)addr;
 				log_printf(
@@ -440,8 +440,8 @@ parsed_prefix:
 					goto unrecognized_opcode;
 				case 2: // CALL rm
 					log_print("\nOpcode: ");
-					if condition_unlikely(rep_type == 1) log_print("BND ");
-					if condition_unlikely(segment == 3) log_print("NOTRACK ");
+					if UNEXPECTED(rep_type == 1) log_print("BND ");
+					if UNEXPECTED(segment == 3) log_print("NOTRACK ");
 					log_print("CALL ");
 				print_indirect:
 					mod = opcode >> 6;
@@ -617,7 +617,7 @@ parsed_prefix:
 #ifdef TH_X64
 								case 6: // Relative addr
 									final_addr = addr + 4 + offset;
-									if condition_unlikely(addrsize) final_addr = (uint32_t)final_addr;
+									if UNEXPECTED(addrsize) final_addr = (uint32_t)final_addr;
 									if (offset >= 0) {
 										log_printf(
 											!addrsize ? "RIP + 0x%X] (0x%p)" : "EIP + 0x%X] (0x%08X)"
@@ -769,8 +769,8 @@ parsed_prefix:
 					TH_UNREACHABLE;
 				case 4: // JMP rm
 					log_print("\nOpcode: ");
-					if condition_unlikely(rep_type == 1) log_print("BND ");
-					if condition_unlikely(segment == 3) log_print("NOTRACK ");
+					if UNEXPECTED(rep_type == 1) log_print("BND ");
+					if UNEXPECTED(segment == 3) log_print("NOTRACK ");
 					log_print("JMP ");
 					goto print_indirect;
 				case 5: // JMP FAR m
@@ -820,7 +820,7 @@ static void log_print_context(CONTEXT* ctx)
 			);
 #endif
 		}
-		if condition_unlikely(last_branch_logging) {
+		if UNEXPECTED(last_branch_logging) {
 #ifdef TH_X64
 			uintptr_t exception_from = ctx->LastExceptionFromRip;
 #else
@@ -1187,7 +1187,7 @@ TH_CALLER_FREE static char* get_windows_error_message(DWORD ExceptionCode) {
 	HGLOBAL resource_handle = LoadResource(ntdll_handle, resource_info_handle);
 
 	MESSAGE_RESOURCE_DATA* resource_pointer = (MESSAGE_RESOURCE_DATA*)LockResource(resource_handle);
-	if condition_unlikely(resource_pointer == NULL) {
+	if UNEXPECTED(resource_pointer == NULL) {
 		// TODO Figure out why Wine isn't finding the message table resource in ntdll
 		return NULL;
 	}

--- a/thcrap/src/expression.cpp
+++ b/thcrap/src/expression.cpp
@@ -331,7 +331,7 @@ struct CPUID_Data_t {
 				}
 			case 6: case 5: case 4: case 3: case 2:
 				__cpuid(data, 0x20000000);
-				if unexpected(data[0] > 0) {
+				if condition_unlikely(data[0] > 0) {
 					__cpuid(data, 0x20000001);
 					HasMVEX = bittest32(data[3], 4);
 				}
@@ -1220,7 +1220,7 @@ static size_t ApplyOperator(const size_t value, const size_t arg, const op_t op)
 static inline const patch_val_t* GetOptionValue(const char* name, size_t name_length) {
 	ExpressionLogging("Option: \"%.*s\"\n", name_length, name);
 	const patch_val_t* const option = patch_opt_get_len(name, name_length);
-	if unexpected(!option) {
+	if condition_unlikely(!option) {
 		OptionNotFoundErrorMessage(name, name_length);
 	}
 	return option;
@@ -1435,7 +1435,7 @@ static uintptr_t GetCodecaveAddress(const char *const name, const size_t name_le
 			switch ((bool)(user_offset_expr == user_offset_expr_next)) {
 				case true: {
 					// If a hex value doesn't work, try a subexpression
-					if unexpected(!eval_expr_impl(user_offset_expr, is_relative ? ']' : '>', &user_offset_value, StartNoOp, 0, data_refs)) {
+					if condition_unlikely(!eval_expr_impl(user_offset_expr, is_relative ? ']' : '>', &user_offset_value, StartNoOp, 0, data_refs)) {
 						ExpressionErrorMessage();
 						break;
 					}
@@ -1457,7 +1457,7 @@ static uintptr_t GetBPFuncOrRawAddress(const char *const name, const size_t name
 	uintptr_t addr = func_get_len(name, name_length);
 	switch (addr) {
 		case 0: {// Will be null if the name was not a BP function
-			if unexpected(!eval_expr_impl(name, is_relative ? ']' : '>', &addr, StartNoOp, 0, data_refs)) {
+			if condition_unlikely(!eval_expr_impl(name, is_relative ? ']' : '>', &addr, StartNoOp, 0, data_refs)) {
 				ExpressionErrorMessage();
 				break;
 			}
@@ -1570,7 +1570,7 @@ static TH_NOINLINE const char* get_patch_value_impl(const char* expr, patch_val_
 	ExpressionLogging("Patch value opening char: \"%hhX\"\n", expr[0]);
 	const char* patch_val_end = find_matching_end(expr, expr[0] == '[' ? TextInt('[', ']') : TextInt('<', '>'));
 	ExpressionLogging("Patch value end: \"%s\"\n", patch_val_end ? patch_val_end : "NULL");
-	if unexpected(!patch_val_end) {
+	if condition_unlikely(!patch_val_end) {
 		//Bracket error
 		return NULL;
 	}
@@ -1978,7 +1978,7 @@ static const char* consume_value_impl(const char* expr, size_t *const out, const
 			// Unary Operators
 			case '!': case '~': case '+': case '-': {
 				expr_next = consume_value_impl(expr + 1 + (expr[0] == expr[1]), out, data_refs);
-				if unexpected(!expr_next) goto InvalidValueError;
+				if condition_unlikely(!expr_next) goto InvalidValueError;
 				switch ((uint8_t)expr[0] << (uint8_t)(expr[0] == expr[1])) {
 					case '~': *out = ~*out; break;
 					case '!': *out = !*out; break;
@@ -1995,7 +1995,7 @@ static const char* consume_value_impl(const char* expr, size_t *const out, const
 			case '*': {
 				// expr + 1 is used to avoid creating a loop
 				expr_next = consume_value_impl(expr + 1, out, data_refs);
-				if unexpected(!expr_next) goto InvalidValueError;
+				if condition_unlikely(!expr_next) goto InvalidValueError;
 				goto SharedDeref;
 			}
 			// Casts and subexpression values
@@ -2015,7 +2015,7 @@ static const char* consume_value_impl(const char* expr, size_t *const out, const
 					*/
 					// Casts
 					expr_next = consume_value_impl(expr_next, out, data_refs);
-					if unexpected(!expr_next) goto InvalidValueError;
+					if condition_unlikely(!expr_next) goto InvalidValueError;
 					++expr_next;
 					if (cur_value.type != PVT_DEFAULT) {
 						switch (cur_value.type) {
@@ -2041,7 +2041,7 @@ static const char* consume_value_impl(const char* expr, size_t *const out, const
 				else {
 					// Subexpressions
 					expr_next = eval_expr_impl(expr, ')', out, StartNoOp, 0, data_refs);
-					if unexpected(!expr_next) goto InvalidExpressionError;
+					if condition_unlikely(!expr_next) goto InvalidExpressionError;
 					++expr_next;
 				}
 				goto PostfixCheck;
@@ -2052,10 +2052,10 @@ static const char* consume_value_impl(const char* expr, size_t *const out, const
 					// Dereference
 					// expr + 1 is used to avoid creating a loop
 					expr_next = eval_expr_impl(expr + 1, ']', out, StartNoOp, 0, data_refs);
-					if unexpected(!expr_next) goto InvalidExpressionError;
+					if condition_unlikely(!expr_next) goto InvalidExpressionError;
 					++expr_next;
 			SharedDeref:
-					if unexpected(!*out) goto NullDerefWarning;
+					if condition_unlikely(!*out) goto NullDerefWarning;
 					if (cur_value.type == PVT_DEFAULT) {
 						*out = *(size_t*)*out;
 					}
@@ -2092,7 +2092,7 @@ static const char* consume_value_impl(const char* expr, size_t *const out, const
 			case '<': {
 				// DON'T use expr + 1 since that kills get_patch_value
 				expr_next = get_patch_value_impl(expr, &cur_value, data_refs);
-				if unexpected(!expr_next) goto PatchValueBracketError;
+				if condition_unlikely(!expr_next) goto PatchValueBracketError;
 				switch (cur_value.type) {
 					case PVT_BYTE: *out = (size_t)cur_value.b; break;
 					case PVT_SBYTE: *out = (size_t)cur_value.sb; break;
@@ -2201,7 +2201,7 @@ static const char* eval_expr_impl(const char* expr, char end, size_t *const out,
 
 		if (ops_cur != NullOp) {
 			const char* expr_next_val = consume_value_impl(expr, &cur_value, data_refs);
-			if unexpected(!expr_next_val) goto InvalidValueError;
+			if condition_unlikely(!expr_next_val) goto InvalidValueError;
 			expr = expr_next_val;
 		}
 
@@ -2224,7 +2224,7 @@ static const char* eval_expr_impl(const char* expr, char end, size_t *const out,
 				switch (ops_next) {
 					default:
 						expr = eval_expr_impl(expr, end, &cur_value, ops_next, cur_value, data_refs);
-						if unexpected(!expr) goto InvalidExpressionError;
+						if condition_unlikely(!expr) goto InvalidExpressionError;
 						ExpressionLogging(
 							"\tRETURN FROM SUBEXPRESSION\n"
 							"\tRemaining: \"%s\"\n",
@@ -2239,11 +2239,11 @@ static const char* eval_expr_impl(const char* expr, char end, size_t *const out,
 								ExpressionLogging("Ternary TRUE compare: \"%s\"\n", expr);
 								if (expr[0] != ':') {
 									expr = eval_expr_impl(expr, ':', &cur_value, StartNoOp, 0, data_refs);
-									if unexpected(!expr) goto InvalidExpressionError;
+									if condition_unlikely(!expr) goto InvalidExpressionError;
 								}
 								ExpressionLogging("Skipping value until %hhX in \"%s\"...\n", end, expr);
 								expr = skip_value(expr, end);
-								if unexpected(!expr) goto InvalidExpressionError;
+								if condition_unlikely(!expr) goto InvalidExpressionError;
 								ExpressionLogging(
 									"Skipping completed\n"
 									"Ternary TRUE remaining: \"%s\" with end \"%hhX\"\n",
@@ -2259,7 +2259,7 @@ static const char* eval_expr_impl(const char* expr, char end, size_t *const out,
 								DisableCodecaveNotFound = true;
 								expr = eval_expr_impl(expr, ':', &dummy_cur_value, StartNoOp, 0, data_refs);
 								DisableCodecaveNotFound = false;
-								if unexpected(!expr) goto InvalidExpressionError;
+								if condition_unlikely(!expr) goto InvalidExpressionError;
 								while (*expr++ != ':');
 								ExpressionLogging(
 									"Skipping completed\n"
@@ -2286,17 +2286,17 @@ static const char* eval_expr_impl(const char* expr, char end, size_t *const out,
 				// is pretty terrible for a recursive function. Screw that.
 				if ((uint8_t)(cur_prec - OpData.Precedence[Assign]) <= (OpData.Precedence[TernaryConditional] - OpData.Precedence[Assign])) {
 					expr = eval_expr_impl(expr, end, &cur_value, ops_next, cur_value, data_refs);
-					if unexpected(!expr) goto InvalidExpressionError;
+					if condition_unlikely(!expr) goto InvalidExpressionError;
 				}
 				/*switch (cur_prec) {
 					case OpData.Precedence[TernaryConditional]:
 					case OpData.Precedence[Assign]:
 						expr = eval_expr_impl(expr, end, &cur_value, ops_next, cur_value, data_refs);
-						if unexpected(!expr) goto InvalidExpressionError;
+						if condition_unlikely(!expr) goto InvalidExpressionError;
 				}*/
 				/*if (OpData.Associativity[ops_cur] == RightAssociative) {
 					expr = eval_expr_impl(expr, end, &cur_value, ops_next, cur_value, data_refs);
-					if unexpected(!expr) goto InvalidExpressionError;
+					if condition_unlikely(!expr) goto InvalidExpressionError;
 				}*/
 				break;
 			case HigherThanNext:

--- a/thcrap/src/expression.cpp
+++ b/thcrap/src/expression.cpp
@@ -331,7 +331,7 @@ struct CPUID_Data_t {
 				}
 			case 6: case 5: case 4: case 3: case 2:
 				__cpuid(data, 0x20000000);
-				if condition_unlikely(data[0] > 0) {
+				if UNEXPECTED(data[0] > 0) {
 					__cpuid(data, 0x20000001);
 					HasMVEX = bittest32(data[3], 4);
 				}
@@ -1220,7 +1220,7 @@ static size_t ApplyOperator(const size_t value, const size_t arg, const op_t op)
 static inline const patch_val_t* GetOptionValue(const char* name, size_t name_length) {
 	ExpressionLogging("Option: \"%.*s\"\n", name_length, name);
 	const patch_val_t* const option = patch_opt_get_len(name, name_length);
-	if condition_unlikely(!option) {
+	if UNEXPECTED(!option) {
 		OptionNotFoundErrorMessage(name, name_length);
 	}
 	return option;
@@ -1435,7 +1435,7 @@ static uintptr_t GetCodecaveAddress(const char *const name, const size_t name_le
 			switch ((bool)(user_offset_expr == user_offset_expr_next)) {
 				case true: {
 					// If a hex value doesn't work, try a subexpression
-					if condition_unlikely(!eval_expr_impl(user_offset_expr, is_relative ? ']' : '>', &user_offset_value, StartNoOp, 0, data_refs)) {
+					if UNEXPECTED(!eval_expr_impl(user_offset_expr, is_relative ? ']' : '>', &user_offset_value, StartNoOp, 0, data_refs)) {
 						ExpressionErrorMessage();
 						break;
 					}
@@ -1457,7 +1457,7 @@ static uintptr_t GetBPFuncOrRawAddress(const char *const name, const size_t name
 	uintptr_t addr = func_get_len(name, name_length);
 	switch (addr) {
 		case 0: {// Will be null if the name was not a BP function
-			if condition_unlikely(!eval_expr_impl(name, is_relative ? ']' : '>', &addr, StartNoOp, 0, data_refs)) {
+			if UNEXPECTED(!eval_expr_impl(name, is_relative ? ']' : '>', &addr, StartNoOp, 0, data_refs)) {
 				ExpressionErrorMessage();
 				break;
 			}
@@ -1570,7 +1570,7 @@ static TH_NOINLINE const char* get_patch_value_impl(const char* expr, patch_val_
 	ExpressionLogging("Patch value opening char: \"%hhX\"\n", expr[0]);
 	const char* patch_val_end = find_matching_end(expr, expr[0] == '[' ? TextInt('[', ']') : TextInt('<', '>'));
 	ExpressionLogging("Patch value end: \"%s\"\n", patch_val_end ? patch_val_end : "NULL");
-	if condition_unlikely(!patch_val_end) {
+	if UNEXPECTED(!patch_val_end) {
 		//Bracket error
 		return NULL;
 	}
@@ -1978,7 +1978,7 @@ static const char* consume_value_impl(const char* expr, size_t *const out, const
 			// Unary Operators
 			case '!': case '~': case '+': case '-': {
 				expr_next = consume_value_impl(expr + 1 + (expr[0] == expr[1]), out, data_refs);
-				if condition_unlikely(!expr_next) goto InvalidValueError;
+				if UNEXPECTED(!expr_next) goto InvalidValueError;
 				switch ((uint8_t)expr[0] << (uint8_t)(expr[0] == expr[1])) {
 					case '~': *out = ~*out; break;
 					case '!': *out = !*out; break;
@@ -1995,7 +1995,7 @@ static const char* consume_value_impl(const char* expr, size_t *const out, const
 			case '*': {
 				// expr + 1 is used to avoid creating a loop
 				expr_next = consume_value_impl(expr + 1, out, data_refs);
-				if condition_unlikely(!expr_next) goto InvalidValueError;
+				if UNEXPECTED(!expr_next) goto InvalidValueError;
 				goto SharedDeref;
 			}
 			// Casts and subexpression values
@@ -2015,7 +2015,7 @@ static const char* consume_value_impl(const char* expr, size_t *const out, const
 					*/
 					// Casts
 					expr_next = consume_value_impl(expr_next, out, data_refs);
-					if condition_unlikely(!expr_next) goto InvalidValueError;
+					if UNEXPECTED(!expr_next) goto InvalidValueError;
 					++expr_next;
 					if (cur_value.type != PVT_DEFAULT) {
 						switch (cur_value.type) {
@@ -2041,7 +2041,7 @@ static const char* consume_value_impl(const char* expr, size_t *const out, const
 				else {
 					// Subexpressions
 					expr_next = eval_expr_impl(expr, ')', out, StartNoOp, 0, data_refs);
-					if condition_unlikely(!expr_next) goto InvalidExpressionError;
+					if UNEXPECTED(!expr_next) goto InvalidExpressionError;
 					++expr_next;
 				}
 				goto PostfixCheck;
@@ -2052,10 +2052,10 @@ static const char* consume_value_impl(const char* expr, size_t *const out, const
 					// Dereference
 					// expr + 1 is used to avoid creating a loop
 					expr_next = eval_expr_impl(expr + 1, ']', out, StartNoOp, 0, data_refs);
-					if condition_unlikely(!expr_next) goto InvalidExpressionError;
+					if UNEXPECTED(!expr_next) goto InvalidExpressionError;
 					++expr_next;
 			SharedDeref:
-					if condition_unlikely(!*out) goto NullDerefWarning;
+					if UNEXPECTED(!*out) goto NullDerefWarning;
 					if (cur_value.type == PVT_DEFAULT) {
 						*out = *(size_t*)*out;
 					}
@@ -2092,7 +2092,7 @@ static const char* consume_value_impl(const char* expr, size_t *const out, const
 			case '<': {
 				// DON'T use expr + 1 since that kills get_patch_value
 				expr_next = get_patch_value_impl(expr, &cur_value, data_refs);
-				if condition_unlikely(!expr_next) goto PatchValueBracketError;
+				if UNEXPECTED(!expr_next) goto PatchValueBracketError;
 				switch (cur_value.type) {
 					case PVT_BYTE: *out = (size_t)cur_value.b; break;
 					case PVT_SBYTE: *out = (size_t)cur_value.sb; break;
@@ -2201,7 +2201,7 @@ static const char* eval_expr_impl(const char* expr, char end, size_t *const out,
 
 		if (ops_cur != NullOp) {
 			const char* expr_next_val = consume_value_impl(expr, &cur_value, data_refs);
-			if condition_unlikely(!expr_next_val) goto InvalidValueError;
+			if UNEXPECTED(!expr_next_val) goto InvalidValueError;
 			expr = expr_next_val;
 		}
 
@@ -2224,7 +2224,7 @@ static const char* eval_expr_impl(const char* expr, char end, size_t *const out,
 				switch (ops_next) {
 					default:
 						expr = eval_expr_impl(expr, end, &cur_value, ops_next, cur_value, data_refs);
-						if condition_unlikely(!expr) goto InvalidExpressionError;
+						if UNEXPECTED(!expr) goto InvalidExpressionError;
 						ExpressionLogging(
 							"\tRETURN FROM SUBEXPRESSION\n"
 							"\tRemaining: \"%s\"\n",
@@ -2239,11 +2239,11 @@ static const char* eval_expr_impl(const char* expr, char end, size_t *const out,
 								ExpressionLogging("Ternary TRUE compare: \"%s\"\n", expr);
 								if (expr[0] != ':') {
 									expr = eval_expr_impl(expr, ':', &cur_value, StartNoOp, 0, data_refs);
-									if condition_unlikely(!expr) goto InvalidExpressionError;
+									if UNEXPECTED(!expr) goto InvalidExpressionError;
 								}
 								ExpressionLogging("Skipping value until %hhX in \"%s\"...\n", end, expr);
 								expr = skip_value(expr, end);
-								if condition_unlikely(!expr) goto InvalidExpressionError;
+								if UNEXPECTED(!expr) goto InvalidExpressionError;
 								ExpressionLogging(
 									"Skipping completed\n"
 									"Ternary TRUE remaining: \"%s\" with end \"%hhX\"\n",
@@ -2259,7 +2259,7 @@ static const char* eval_expr_impl(const char* expr, char end, size_t *const out,
 								DisableCodecaveNotFound = true;
 								expr = eval_expr_impl(expr, ':', &dummy_cur_value, StartNoOp, 0, data_refs);
 								DisableCodecaveNotFound = false;
-								if condition_unlikely(!expr) goto InvalidExpressionError;
+								if UNEXPECTED(!expr) goto InvalidExpressionError;
 								while (*expr++ != ':');
 								ExpressionLogging(
 									"Skipping completed\n"
@@ -2286,17 +2286,17 @@ static const char* eval_expr_impl(const char* expr, char end, size_t *const out,
 				// is pretty terrible for a recursive function. Screw that.
 				if ((uint8_t)(cur_prec - OpData.Precedence[Assign]) <= (OpData.Precedence[TernaryConditional] - OpData.Precedence[Assign])) {
 					expr = eval_expr_impl(expr, end, &cur_value, ops_next, cur_value, data_refs);
-					if condition_unlikely(!expr) goto InvalidExpressionError;
+					if UNEXPECTED(!expr) goto InvalidExpressionError;
 				}
 				/*switch (cur_prec) {
 					case OpData.Precedence[TernaryConditional]:
 					case OpData.Precedence[Assign]:
 						expr = eval_expr_impl(expr, end, &cur_value, ops_next, cur_value, data_refs);
-						if condition_unlikely(!expr) goto InvalidExpressionError;
+						if UNEXPECTED(!expr) goto InvalidExpressionError;
 				}*/
 				/*if (OpData.Associativity[ops_cur] == RightAssociative) {
 					expr = eval_expr_impl(expr, end, &cur_value, ops_next, cur_value, data_refs);
-					if condition_unlikely(!expr) goto InvalidExpressionError;
+					if UNEXPECTED(!expr) goto InvalidExpressionError;
 				}*/
 				break;
 			case HigherThanNext:

--- a/thcrap/src/global.cpp
+++ b/thcrap/src/global.cpp
@@ -114,7 +114,7 @@ template<typename T, typename L>
 inline T globalconfig_get(const L& json_T_value, const char* key, const T default_value)
 {
 	json_t* cfg = global_cfg;
-	if unexpected(!cfg) {
+	if condition_unlikely(!cfg) {
 		cfg = globalconfig_init();
 	}
 	json_t* value_json = json_object_get(cfg, key);
@@ -128,7 +128,7 @@ template<typename T, typename L>
 int globalconfig_set(const L& json_T, const char* key, const T value)
 {
 	json_t* cfg = global_cfg;
-	if unexpected(!cfg) {
+	if condition_unlikely(!cfg) {
 		cfg = globalconfig_init();
 	}
 	json_t* j_value = json_T(value);

--- a/thcrap/src/global.cpp
+++ b/thcrap/src/global.cpp
@@ -114,7 +114,7 @@ template<typename T, typename L>
 inline T globalconfig_get(const L& json_T_value, const char* key, const T default_value)
 {
 	json_t* cfg = global_cfg;
-	if condition_unlikely(!cfg) {
+	if UNEXPECTED(!cfg) {
 		cfg = globalconfig_init();
 	}
 	json_t* value_json = json_object_get(cfg, key);
@@ -128,7 +128,7 @@ template<typename T, typename L>
 int globalconfig_set(const L& json_T, const char* key, const T value)
 {
 	json_t* cfg = global_cfg;
-	if condition_unlikely(!cfg) {
+	if UNEXPECTED(!cfg) {
 		cfg = globalconfig_init();
 	}
 	json_t* j_value = json_T(value);

--- a/thcrap/src/inject.cpp
+++ b/thcrap/src/inject.cpp
@@ -353,7 +353,7 @@ int Inject(const HANDLE hProcess, const wchar_t *const dll_dir, const wchar_t *c
 
 	if (dll_dir) {
 		HANDLE set_dir_thread = CreateRemoteThread(hProcess, NULL, 0, (LPTHREAD_START_ROUTINE)&SetCurrentDirectoryW, CodecaveAddress + dll_dir_offset, 0, NULL);
-		if unexpected(set_dir_thread == NULL) {
+		if condition_unlikely(set_dir_thread == NULL) {
 			goto fail;
 		}
 		WaitForSingleObject(set_dir_thread, INFINITE);
@@ -365,7 +365,7 @@ int Inject(const HANDLE hProcess, const wchar_t *const dll_dir, const wchar_t *c
 	set_pid_to_wait_for((HANDLE)process_info.UniqueProcessId);
 
 	HANDLE library_load_thread = CreateRemoteThread(hProcess, NULL, 0, (LPTHREAD_START_ROUTINE)&LoadLibraryW, CodecaveAddress + injector_dll_offset, 0, NULL);
-	if unexpected(library_load_thread == NULL) {
+	if condition_unlikely(library_load_thread == NULL) {
 		clear_pid_to_wait_for((HANDLE)process_info.UniqueProcessId);
 		goto fail;
 	}
@@ -376,7 +376,7 @@ int Inject(const HANDLE hProcess, const wchar_t *const dll_dir, const wchar_t *c
 	CloseHandle(library_load_thread);
 
 	HANDLE init_thread = CreateRemoteThread(hProcess, NULL, 0, (LPTHREAD_START_ROUTINE)init_addr, CodecaveAddress, 0, NULL);
-	if unexpected(init_thread == NULL) {
+	if condition_unlikely(init_thread == NULL) {
 		goto fail;
 	}
 	WaitForSingleObject(init_thread, INFINITE);
@@ -384,7 +384,7 @@ int Inject(const HANDLE hProcess, const wchar_t *const dll_dir, const wchar_t *c
 
 	if (dll_dir) {
 		HANDLE restore_dir_thread = CreateRemoteThread(hProcess, NULL, 0, (LPTHREAD_START_ROUTINE)&SetCurrentDirectoryW, CodecaveAddress + prev_current_directory_offset, 0, NULL);
-		if unexpected(restore_dir_thread == NULL) {
+		if condition_unlikely(restore_dir_thread == NULL) {
 			goto fail;
 		}
 		WaitForSingleObject(restore_dir_thread, INFINITE);

--- a/thcrap/src/inject.cpp
+++ b/thcrap/src/inject.cpp
@@ -353,7 +353,7 @@ int Inject(const HANDLE hProcess, const wchar_t *const dll_dir, const wchar_t *c
 
 	if (dll_dir) {
 		HANDLE set_dir_thread = CreateRemoteThread(hProcess, NULL, 0, (LPTHREAD_START_ROUTINE)&SetCurrentDirectoryW, CodecaveAddress + dll_dir_offset, 0, NULL);
-		if condition_unlikely(set_dir_thread == NULL) {
+		if UNEXPECTED(set_dir_thread == NULL) {
 			goto fail;
 		}
 		WaitForSingleObject(set_dir_thread, INFINITE);
@@ -365,7 +365,7 @@ int Inject(const HANDLE hProcess, const wchar_t *const dll_dir, const wchar_t *c
 	set_pid_to_wait_for((HANDLE)process_info.UniqueProcessId);
 
 	HANDLE library_load_thread = CreateRemoteThread(hProcess, NULL, 0, (LPTHREAD_START_ROUTINE)&LoadLibraryW, CodecaveAddress + injector_dll_offset, 0, NULL);
-	if condition_unlikely(library_load_thread == NULL) {
+	if UNEXPECTED(library_load_thread == NULL) {
 		clear_pid_to_wait_for((HANDLE)process_info.UniqueProcessId);
 		goto fail;
 	}
@@ -376,7 +376,7 @@ int Inject(const HANDLE hProcess, const wchar_t *const dll_dir, const wchar_t *c
 	CloseHandle(library_load_thread);
 
 	HANDLE init_thread = CreateRemoteThread(hProcess, NULL, 0, (LPTHREAD_START_ROUTINE)init_addr, CodecaveAddress, 0, NULL);
-	if condition_unlikely(init_thread == NULL) {
+	if UNEXPECTED(init_thread == NULL) {
 		goto fail;
 	}
 	WaitForSingleObject(init_thread, INFINITE);
@@ -384,7 +384,7 @@ int Inject(const HANDLE hProcess, const wchar_t *const dll_dir, const wchar_t *c
 
 	if (dll_dir) {
 		HANDLE restore_dir_thread = CreateRemoteThread(hProcess, NULL, 0, (LPTHREAD_START_ROUTINE)&SetCurrentDirectoryW, CodecaveAddress + prev_current_directory_offset, 0, NULL);
-		if condition_unlikely(restore_dir_thread == NULL) {
+		if UNEXPECTED(restore_dir_thread == NULL) {
 			goto fail;
 		}
 		WaitForSingleObject(restore_dir_thread, INFINITE);

--- a/thcrap/src/jansson_ex.cpp
+++ b/thcrap/src/jansson_ex.cpp
@@ -36,7 +36,7 @@ TH_CALLER_FREE char* json_string_copy(const json_t* object) {
 }
 
 TH_CALLER_FREE char* json_concat_string_array(const json_t* str_arr, const char *name) {
-	if unexpected(!str_arr) {
+	if condition_unlikely(!str_arr) {
 		return NULL;
 	}
 	switch (json_typeof(str_arr)) {
@@ -408,7 +408,7 @@ json_t* json_load_file_report_size(const char *json_fn, size_t* size_out)
 		size_t json_size;
 		uint8_t* heap_buffer = (uint8_t*)file_read(json_fn, &json_size);
 
-		if unexpected(!heap_buffer || !json_size) {
+		if condition_unlikely(!heap_buffer || !json_size) {
 			break;
 		}
 
@@ -537,7 +537,7 @@ static inline jeval_error_t json_evaluate(const json_t* json, uint8_t eval_confi
 				return JEVAL_SUCCESS;
 			}
 			case JSON_STRING: {
-				if unexpected(eval_config & JEVAL_NO_EXPRS) return JEVAL_ERROR_STRING_NO_EXPRS;
+				if condition_unlikely(eval_config & JEVAL_NO_EXPRS) return JEVAL_ERROR_STRING_NO_EXPRS;
 				if (strict & (eval_type == JEVAL_REAL)) return JEVAL_ERROR_STRICT_TYPE_MISMATCH;
 				const size_t expr_value = json_string_expression_value(json);
 				SetOutValues((bool)expr_value, (json_int_t)expr_value, (double)expr_value);

--- a/thcrap/src/jansson_ex.cpp
+++ b/thcrap/src/jansson_ex.cpp
@@ -36,7 +36,7 @@ TH_CALLER_FREE char* json_string_copy(const json_t* object) {
 }
 
 TH_CALLER_FREE char* json_concat_string_array(const json_t* str_arr, const char *name) {
-	if condition_unlikely(!str_arr) {
+	if UNEXPECTED(!str_arr) {
 		return NULL;
 	}
 	switch (json_typeof(str_arr)) {
@@ -408,7 +408,7 @@ json_t* json_load_file_report_size(const char *json_fn, size_t* size_out)
 		size_t json_size;
 		uint8_t* heap_buffer = (uint8_t*)file_read(json_fn, &json_size);
 
-		if condition_unlikely(!heap_buffer || !json_size) {
+		if UNEXPECTED(!heap_buffer || !json_size) {
 			break;
 		}
 
@@ -537,7 +537,7 @@ static inline jeval_error_t json_evaluate(const json_t* json, uint8_t eval_confi
 				return JEVAL_SUCCESS;
 			}
 			case JSON_STRING: {
-				if condition_unlikely(eval_config & JEVAL_NO_EXPRS) return JEVAL_ERROR_STRING_NO_EXPRS;
+				if UNEXPECTED(eval_config & JEVAL_NO_EXPRS) return JEVAL_ERROR_STRING_NO_EXPRS;
 				if (strict & (eval_type == JEVAL_REAL)) return JEVAL_ERROR_STRICT_TYPE_MISMATCH;
 				const size_t expr_value = json_string_expression_value(json);
 				SetOutValues((bool)expr_value, (json_int_t)expr_value, (double)expr_value);

--- a/thcrap/src/log.cpp
+++ b/thcrap/src/log.cpp
@@ -103,7 +103,7 @@ void log_rotate(void)
 
 static void log_print_real(const char* str, uint32_t n, bool is_n) {
 	static DWORD byteRet;
-	if unexpected(console_open) {
+	if condition_unlikely(console_open) {
 		WriteFile(GetStdHandle(STD_OUTPUT_HANDLE), str, n, &byteRet, NULL);
 	}
 	if (HANDLE file = log_file) {

--- a/thcrap/src/log.cpp
+++ b/thcrap/src/log.cpp
@@ -103,7 +103,7 @@ void log_rotate(void)
 
 static void log_print_real(const char* str, uint32_t n, bool is_n) {
 	static DWORD byteRet;
-	if condition_unlikely(console_open) {
+	if UNEXPECTED(console_open) {
 		WriteFile(GetStdHandle(STD_OUTPUT_HANDLE), str, n, &byteRet, NULL);
 	}
 	if (HANDLE file = log_file) {

--- a/thcrap/src/mempatch.cpp
+++ b/thcrap/src/mempatch.cpp
@@ -31,7 +31,7 @@ struct detour_func_map_t {
 
 			void* chain_ptr = (void*)emplace_result.first->second;
 
-			if unexpected(!chain_ptr) {
+			if condition_unlikely(!chain_ptr) {
 				// Detour is disabled
 				return;
 			}

--- a/thcrap/src/mempatch.cpp
+++ b/thcrap/src/mempatch.cpp
@@ -31,7 +31,7 @@ struct detour_func_map_t {
 
 			void* chain_ptr = (void*)emplace_result.first->second;
 
-			if condition_unlikely(!chain_ptr) {
+			if UNEXPECTED(!chain_ptr) {
 				// Detour is disabled
 				return;
 			}

--- a/thcrap/src/patchfile.cpp
+++ b/thcrap/src/patchfile.cpp
@@ -87,7 +87,7 @@ void* (file_read)(const char *fn, size_t *file_size)
 
 int file_write(const char *fn, const void *file_buffer, size_t file_size)
 {
-	if unexpected(!fn || !file_buffer || !file_size) {
+	if condition_unlikely(!fn || !file_buffer || !file_size) {
 		return ERROR_INVALID_PARAMETER;
 	}
 
@@ -97,7 +97,7 @@ int file_write(const char *fn, const void *file_buffer, size_t file_size)
 		fn, GENERIC_WRITE, 0, NULL, CREATE_ALWAYS,
 		FILE_ATTRIBUTE_NORMAL | FILE_FLAG_SEQUENTIAL_SCAN, NULL
 	);
-	if unexpected(handle == INVALID_HANDLE_VALUE) {
+	if condition_unlikely(handle == INVALID_HANDLE_VALUE) {
 		return GetLastError();
 	}
 #ifndef TH_X64
@@ -107,7 +107,7 @@ int file_write(const char *fn, const void *file_buffer, size_t file_size)
 	DWORD idgaf;
 	int ret;
 	for (; file_size > UINT32_MAX; file_size -= UINT32_MAX) {
-		if unexpected(!WriteFile(handle, file_buffer_reader, UINT32_MAX, &idgaf, NULL)) {
+		if condition_unlikely(!WriteFile(handle, file_buffer_reader, UINT32_MAX, &idgaf, NULL)) {
 			goto get_error;
 		}
 		file_buffer_reader += UINT32_MAX;
@@ -187,7 +187,7 @@ int dir_create_for_fn(const char *fn)
 
 TH_CALLER_FREE char* fn_for_patch(const patch_t *patch_info, const char *fn)
 {
-	if unexpected(!patch_info || !patch_info->archive || !fn) {
+	if condition_unlikely(!patch_info || !patch_info->archive || !fn) {
 		return NULL;
 	}
 	/*if(char archive_end = patch_info->archive[patch_info->archive_length - 1];
@@ -203,7 +203,7 @@ TH_CALLER_FREE char* fn_for_patch(const patch_t *patch_info, const char *fn)
 
 int patch_file_exists(const patch_t *patch_info, const char *fn)
 {
-	if unexpected(patch_file_blacklisted(patch_info, fn)) {
+	if condition_unlikely(patch_file_blacklisted(patch_info, fn)) {
 		return false;
 	}
 	BOOL ret = FALSE;
@@ -216,7 +216,7 @@ int patch_file_exists(const patch_t *patch_info, const char *fn)
 
 int patch_file_blacklisted(const patch_t *patch_info, const char *fn)
 {
-	if unexpected(patch_info->ignore) {
+	if condition_unlikely(patch_info->ignore) {
 		for (size_t i = 0; patch_info->ignore[i]; i++) {
 			if (PathMatchSpecExU(fn, patch_info->ignore[i], PMSF_NORMAL) == S_OK) {
 				return 1;
@@ -295,7 +295,7 @@ size_t patch_json_merge(json_t **json_inout, const patch_t *patch_info, const ch
 
 int patch_json_store(const patch_t *patch_info, const char *fn, const json_t *json)
 {
-	if unexpected(!patch_info || !fn || !json) {
+	if condition_unlikely(!patch_info || !fn || !json) {
 		return -1;
 	}
 	int ret = -1;
@@ -366,7 +366,7 @@ patch_desc_t patch_dep_to_desc(const char *dep_str)
 {
 	patch_desc_t desc = {};
 
-	if unexpected(!dep_str) {
+	if condition_unlikely(!dep_str) {
 		return desc;
 	}
 
@@ -613,7 +613,7 @@ void patchhook_register(const char *wildcard, func_patch_t patch_func, func_patc
 
 patchhook_t *patchhooks_build(const char *fn)
 {
-	if unexpected(!fn) {
+	if condition_unlikely(!fn) {
 		return NULL;
 	}
 	WCHAR_T_DEC(fn);
@@ -664,7 +664,7 @@ int patchhooks_run(const patchhook_t *hook_array, void *file_inout, size_t size_
 {
 	// We don't check [patch] here - hooks should be run even if there is no
 	// dedicated patch file.
-	if unexpected(!file_inout) {
+	if condition_unlikely(!file_inout) {
 		return -1;
 	}
 	int ret = 0;
@@ -674,7 +674,7 @@ int patchhooks_run(const patchhook_t *hook_array, void *file_inout, size_t size_
 			if (func) {
 				if (func(file_inout, size_out, size_in, fn, patch) > 0) {
 					const char *patched_files_dump = runconfig_patched_files_dump_get();
-					if unexpected(patched_files_dump) {
+					if condition_unlikely(patched_files_dump) {
 						DumpDatFile(patched_files_dump, fn, file_inout, size_out, true);
 					}
 					ret = 1;
@@ -701,7 +701,7 @@ void patch_opts_clear_all() {
 }
 
 patch_value_type_t TH_FASTCALL patch_parse_type(const char *type) {
-	if unexpected(!type) return PVT_UNKNOWN;
+	if condition_unlikely(!type) return PVT_UNKNOWN;
 	switch (const uint8_t type_char = type[0] | 0x20) {
 		case 's': case 'w':
 			size_t char_size;
@@ -874,23 +874,23 @@ void patch_opts_from_json(json_t *opts) {
 	const char *key;
 	json_t *j_val;
 	json_object_foreach_fast(opts, key, j_val) {
-		if unexpected(!json_is_object(j_val)) {
+		if condition_unlikely(!json_is_object(j_val)) {
 			log_printf("ERROR: invalid parameter for option %s\n", key);
 			continue;
 		}
 		json_t *j_val_val = json_object_get(j_val, "val");
-		if unexpected(!j_val_val) {
+		if condition_unlikely(!j_val_val) {
 			continue;
 		}
 		const char *tname = json_object_get_string(j_val, "type");
-		if unexpected(!tname) {
+		if condition_unlikely(!tname) {
 			continue;
 		}
 
 		patch_val_t entry;
 		switch (entry.type = patch_parse_type(tname)) {
 			case PVT_STRING: case PVT_STRING16: case PVT_STRING32: {
-				if unexpected(!json_is_string(j_val_val)) {
+				if condition_unlikely(!json_is_string(j_val_val)) {
 					log_printf("ERROR: invalid json type for string option %s\n", key);
 					continue;
 				}

--- a/thcrap/src/patchfile.cpp
+++ b/thcrap/src/patchfile.cpp
@@ -87,7 +87,7 @@ void* (file_read)(const char *fn, size_t *file_size)
 
 int file_write(const char *fn, const void *file_buffer, size_t file_size)
 {
-	if condition_unlikely(!fn || !file_buffer || !file_size) {
+	if UNEXPECTED(!fn || !file_buffer || !file_size) {
 		return ERROR_INVALID_PARAMETER;
 	}
 
@@ -97,7 +97,7 @@ int file_write(const char *fn, const void *file_buffer, size_t file_size)
 		fn, GENERIC_WRITE, 0, NULL, CREATE_ALWAYS,
 		FILE_ATTRIBUTE_NORMAL | FILE_FLAG_SEQUENTIAL_SCAN, NULL
 	);
-	if condition_unlikely(handle == INVALID_HANDLE_VALUE) {
+	if UNEXPECTED(handle == INVALID_HANDLE_VALUE) {
 		return GetLastError();
 	}
 #ifndef TH_X64
@@ -107,7 +107,7 @@ int file_write(const char *fn, const void *file_buffer, size_t file_size)
 	DWORD idgaf;
 	int ret;
 	for (; file_size > UINT32_MAX; file_size -= UINT32_MAX) {
-		if condition_unlikely(!WriteFile(handle, file_buffer_reader, UINT32_MAX, &idgaf, NULL)) {
+		if UNEXPECTED(!WriteFile(handle, file_buffer_reader, UINT32_MAX, &idgaf, NULL)) {
 			goto get_error;
 		}
 		file_buffer_reader += UINT32_MAX;
@@ -187,7 +187,7 @@ int dir_create_for_fn(const char *fn)
 
 TH_CALLER_FREE char* fn_for_patch(const patch_t *patch_info, const char *fn)
 {
-	if condition_unlikely(!patch_info || !patch_info->archive || !fn) {
+	if UNEXPECTED(!patch_info || !patch_info->archive || !fn) {
 		return NULL;
 	}
 	/*if(char archive_end = patch_info->archive[patch_info->archive_length - 1];
@@ -203,7 +203,7 @@ TH_CALLER_FREE char* fn_for_patch(const patch_t *patch_info, const char *fn)
 
 int patch_file_exists(const patch_t *patch_info, const char *fn)
 {
-	if condition_unlikely(patch_file_blacklisted(patch_info, fn)) {
+	if UNEXPECTED(patch_file_blacklisted(patch_info, fn)) {
 		return false;
 	}
 	BOOL ret = FALSE;
@@ -216,7 +216,7 @@ int patch_file_exists(const patch_t *patch_info, const char *fn)
 
 int patch_file_blacklisted(const patch_t *patch_info, const char *fn)
 {
-	if condition_unlikely(patch_info->ignore) {
+	if UNEXPECTED(patch_info->ignore) {
 		for (size_t i = 0; patch_info->ignore[i]; i++) {
 			if (PathMatchSpecExU(fn, patch_info->ignore[i], PMSF_NORMAL) == S_OK) {
 				return 1;
@@ -295,7 +295,7 @@ size_t patch_json_merge(json_t **json_inout, const patch_t *patch_info, const ch
 
 int patch_json_store(const patch_t *patch_info, const char *fn, const json_t *json)
 {
-	if condition_unlikely(!patch_info || !fn || !json) {
+	if UNEXPECTED(!patch_info || !fn || !json) {
 		return -1;
 	}
 	int ret = -1;
@@ -366,7 +366,7 @@ patch_desc_t patch_dep_to_desc(const char *dep_str)
 {
 	patch_desc_t desc = {};
 
-	if condition_unlikely(!dep_str) {
+	if UNEXPECTED(!dep_str) {
 		return desc;
 	}
 
@@ -613,7 +613,7 @@ void patchhook_register(const char *wildcard, func_patch_t patch_func, func_patc
 
 patchhook_t *patchhooks_build(const char *fn)
 {
-	if condition_unlikely(!fn) {
+	if UNEXPECTED(!fn) {
 		return NULL;
 	}
 	WCHAR_T_DEC(fn);
@@ -664,7 +664,7 @@ int patchhooks_run(const patchhook_t *hook_array, void *file_inout, size_t size_
 {
 	// We don't check [patch] here - hooks should be run even if there is no
 	// dedicated patch file.
-	if condition_unlikely(!file_inout) {
+	if UNEXPECTED(!file_inout) {
 		return -1;
 	}
 	int ret = 0;
@@ -674,7 +674,7 @@ int patchhooks_run(const patchhook_t *hook_array, void *file_inout, size_t size_
 			if (func) {
 				if (func(file_inout, size_out, size_in, fn, patch) > 0) {
 					const char *patched_files_dump = runconfig_patched_files_dump_get();
-					if condition_unlikely(patched_files_dump) {
+					if UNEXPECTED(patched_files_dump) {
 						DumpDatFile(patched_files_dump, fn, file_inout, size_out, true);
 					}
 					ret = 1;
@@ -701,7 +701,7 @@ void patch_opts_clear_all() {
 }
 
 patch_value_type_t TH_FASTCALL patch_parse_type(const char *type) {
-	if condition_unlikely(!type) return PVT_UNKNOWN;
+	if UNEXPECTED(!type) return PVT_UNKNOWN;
 	switch (const uint8_t type_char = type[0] | 0x20) {
 		case 's': case 'w':
 			size_t char_size;
@@ -874,23 +874,23 @@ void patch_opts_from_json(json_t *opts) {
 	const char *key;
 	json_t *j_val;
 	json_object_foreach_fast(opts, key, j_val) {
-		if condition_unlikely(!json_is_object(j_val)) {
+		if UNEXPECTED(!json_is_object(j_val)) {
 			log_printf("ERROR: invalid parameter for option %s\n", key);
 			continue;
 		}
 		json_t *j_val_val = json_object_get(j_val, "val");
-		if condition_unlikely(!j_val_val) {
+		if UNEXPECTED(!j_val_val) {
 			continue;
 		}
 		const char *tname = json_object_get_string(j_val, "type");
-		if condition_unlikely(!tname) {
+		if UNEXPECTED(!tname) {
 			continue;
 		}
 
 		patch_val_t entry;
 		switch (entry.type = patch_parse_type(tname)) {
 			case PVT_STRING: case PVT_STRING16: case PVT_STRING32: {
-				if condition_unlikely(!json_is_string(j_val_val)) {
+				if UNEXPECTED(!json_is_string(j_val_val)) {
 					log_printf("ERROR: invalid json type for string option %s\n", key);
 					continue;
 				}

--- a/thcrap/src/pe.cpp
+++ b/thcrap/src/pe.cpp
@@ -15,19 +15,19 @@
 
 int find_export_in_headers(void* buffer, const char* const func_name) {
 	PIMAGE_DOS_HEADER pDosHeader = (PIMAGE_DOS_HEADER)buffer;
-	if unexpected(pDosHeader->e_magic != IMAGE_DOS_SIGNATURE) {
+	if condition_unlikely(pDosHeader->e_magic != IMAGE_DOS_SIGNATURE) {
 		return INVALID_FILE;
 	}
 	PIMAGE_NT_HEADERS pNtHeader = (PIMAGE_NT_HEADERS)((UINT_PTR)buffer + pDosHeader->e_lfanew);
-	if unexpected(pNtHeader->Signature != IMAGE_NT_SIGNATURE) {
+	if condition_unlikely(pNtHeader->Signature != IMAGE_NT_SIGNATURE) {
 		return INVALID_FILE;
 	}
 #if TH_X86
-	if unexpected(pNtHeader->FileHeader.Machine != IMAGE_FILE_MACHINE_I386) {
+	if condition_unlikely(pNtHeader->FileHeader.Machine != IMAGE_FILE_MACHINE_I386) {
 		return INVALID_FILE;
 	}
 #else
-	if unexpected(pNtHeader->FileHeader.Machine != IMAGE_FILE_MACHINE_AMD64) {
+	if condition_unlikely(pNtHeader->FileHeader.Machine != IMAGE_FILE_MACHINE_AMD64) {
 		return INVALID_FILE;
 	}
 #endif
@@ -77,7 +77,7 @@ int GetExeBits(const char* const path) {
 
 PluginValidation validate_plugin_dll_for_load(const char* const path) {
 	HMODULE dll = LoadLibraryExU(path, NULL, DONT_RESOLVE_DLL_REFERENCES | LOAD_LIBRARY_AS_DATAFILE | LOAD_WITH_ALTERED_SEARCH_PATH);
-	if unexpected(!dll) {
+	if condition_unlikely(!dll) {
 		// Loading completely failed
 		return NOT_A_DLL;
 	}
@@ -116,7 +116,7 @@ bool CheckDLLFunction(const char* const path, const char* const func_name)
 
 PIMAGE_NT_HEADERS GetNtHeader(HMODULE hMod)
 {
-	if unexpected(!hMod) {
+	if condition_unlikely(!hMod) {
 		return 0;
 	}
 
@@ -155,7 +155,7 @@ void *GetNtDataDirectory(HMODULE hMod, BYTE directory)
 PIMAGE_IMPORT_DESCRIPTOR GetDllImportDesc(HMODULE hMod, const char *dll_name)
 {
 	PIMAGE_IMPORT_DESCRIPTOR pImportDesc = (PIMAGE_IMPORT_DESCRIPTOR)GetNtDataDirectory(hMod, IMAGE_DIRECTORY_ENTRY_IMPORT);
-	if unexpected(!pImportDesc) {
+	if condition_unlikely(!pImportDesc) {
 		return NULL;
 	}
 	while(pImportDesc->Name) {
@@ -175,7 +175,7 @@ PIMAGE_EXPORT_DIRECTORY GetDllExportDesc(HMODULE hMod)
 
 PIMAGE_SECTION_HEADER GetSectionHeader(HMODULE hMod, const char *section_name)
 {
-	if unexpected(!hMod || !section_name) {
+	if condition_unlikely(!hMod || !section_name) {
 		return 0;
 	}
 	PIMAGE_NT_HEADERS pNTH = GetNtHeader(hMod);
@@ -322,7 +322,7 @@ void* GetRemoteModuleEntryPoint(HANDLE hProcess, HMODULE hMod)
 
 HMODULE GetRemoteModuleHandle(HANDLE hProcess, const char *search_module)
 {
-	if unexpected(!search_module) {
+	if condition_unlikely(!search_module) {
 		return NULL;
 	}
 
@@ -363,22 +363,22 @@ FARPROC GetRemoteProcAddress(HANDLE hProcess, HMODULE hMod, LPCSTR lpProcName)
 {
 	BYTE *addr = (BYTE*)hMod;
 
-	if unexpected(!lpProcName) {
+	if condition_unlikely(!lpProcName) {
 		return NULL;
 	}
 
 	IMAGE_NT_HEADERS NTH;
-	if unexpected(GetRemoteModuleNtHeader(&NTH, hProcess, hMod)) {
+	if condition_unlikely(GetRemoteModuleNtHeader(&NTH, hProcess, hMod)) {
 		return NULL;
 	}
-	if unexpected(NTH.OptionalHeader.NumberOfRvaAndSizes < IMAGE_DIRECTORY_ENTRY_EXPORT + 1) {
+	if condition_unlikely(NTH.OptionalHeader.NumberOfRvaAndSizes < IMAGE_DIRECTORY_ENTRY_EXPORT + 1) {
 		return NULL;
 	}
 
 	PIMAGE_DATA_DIRECTORY pExportPos = &NTH.OptionalHeader.DataDirectory[IMAGE_DIRECTORY_ENTRY_EXPORT];
 
 	IMAGE_EXPORT_DIRECTORY ExportDesc;
-	if unexpected(!ReadProcessMemory(hProcess, addr + pExportPos->VirtualAddress, &ExportDesc, sizeof(ExportDesc), NULL)) {
+	if condition_unlikely(!ReadProcessMemory(hProcess, addr + pExportPos->VirtualAddress, &ExportDesc, sizeof(ExportDesc), NULL)) {
 		return NULL;
 	}
 
@@ -390,7 +390,7 @@ FARPROC GetRemoteProcAddress(HANDLE hProcess, HMODULE hMod, LPCSTR lpProcName)
 	size_t name_indices_size = ExportDesc.NumberOfNames * sizeof(WORD);
 
 	uint8_t* buffer = (uint8_t*)malloc(func_ptrs_size + name_ptrs_size + name_indices_size);
-	if unexpected(!buffer) {
+	if condition_unlikely(!buffer) {
 		return NULL;
 	}
 

--- a/thcrap/src/pe.cpp
+++ b/thcrap/src/pe.cpp
@@ -15,19 +15,19 @@
 
 int find_export_in_headers(void* buffer, const char* const func_name) {
 	PIMAGE_DOS_HEADER pDosHeader = (PIMAGE_DOS_HEADER)buffer;
-	if condition_unlikely(pDosHeader->e_magic != IMAGE_DOS_SIGNATURE) {
+	if UNEXPECTED(pDosHeader->e_magic != IMAGE_DOS_SIGNATURE) {
 		return INVALID_FILE;
 	}
 	PIMAGE_NT_HEADERS pNtHeader = (PIMAGE_NT_HEADERS)((UINT_PTR)buffer + pDosHeader->e_lfanew);
-	if condition_unlikely(pNtHeader->Signature != IMAGE_NT_SIGNATURE) {
+	if UNEXPECTED(pNtHeader->Signature != IMAGE_NT_SIGNATURE) {
 		return INVALID_FILE;
 	}
 #if TH_X86
-	if condition_unlikely(pNtHeader->FileHeader.Machine != IMAGE_FILE_MACHINE_I386) {
+	if UNEXPECTED(pNtHeader->FileHeader.Machine != IMAGE_FILE_MACHINE_I386) {
 		return INVALID_FILE;
 	}
 #else
-	if condition_unlikely(pNtHeader->FileHeader.Machine != IMAGE_FILE_MACHINE_AMD64) {
+	if UNEXPECTED(pNtHeader->FileHeader.Machine != IMAGE_FILE_MACHINE_AMD64) {
 		return INVALID_FILE;
 	}
 #endif
@@ -55,7 +55,7 @@ int find_export_in_headers(void* buffer, const char* const func_name) {
 
 int GetExeBits(const char* const path) {
 	DWORD attr = GetFileAttributesU(path);
-	if unexpected(attr == INVALID_FILE_ATTRIBUTES) {
+	if UNEXPECTED(attr == INVALID_FILE_ATTRIBUTES) {
 		return -1;
 	}
 	int ret = 0;
@@ -77,7 +77,7 @@ int GetExeBits(const char* const path) {
 
 PluginValidation validate_plugin_dll_for_load(const char* const path) {
 	HMODULE dll = LoadLibraryExU(path, NULL, DONT_RESOLVE_DLL_REFERENCES | LOAD_LIBRARY_AS_DATAFILE | LOAD_WITH_ALTERED_SEARCH_PATH);
-	if condition_unlikely(!dll) {
+	if UNEXPECTED(!dll) {
 		// Loading completely failed
 		return NOT_A_DLL;
 	}
@@ -116,7 +116,7 @@ bool CheckDLLFunction(const char* const path, const char* const func_name)
 
 PIMAGE_NT_HEADERS GetNtHeader(HMODULE hMod)
 {
-	if condition_unlikely(!hMod) {
+	if UNEXPECTED(!hMod) {
 		return 0;
 	}
 
@@ -155,7 +155,7 @@ void *GetNtDataDirectory(HMODULE hMod, BYTE directory)
 PIMAGE_IMPORT_DESCRIPTOR GetDllImportDesc(HMODULE hMod, const char *dll_name)
 {
 	PIMAGE_IMPORT_DESCRIPTOR pImportDesc = (PIMAGE_IMPORT_DESCRIPTOR)GetNtDataDirectory(hMod, IMAGE_DIRECTORY_ENTRY_IMPORT);
-	if condition_unlikely(!pImportDesc) {
+	if UNEXPECTED(!pImportDesc) {
 		return NULL;
 	}
 	while(pImportDesc->Name) {
@@ -175,7 +175,7 @@ PIMAGE_EXPORT_DIRECTORY GetDllExportDesc(HMODULE hMod)
 
 PIMAGE_SECTION_HEADER GetSectionHeader(HMODULE hMod, const char *section_name)
 {
-	if condition_unlikely(!hMod || !section_name) {
+	if UNEXPECTED(!hMod || !section_name) {
 		return 0;
 	}
 	PIMAGE_NT_HEADERS pNTH = GetNtHeader(hMod);
@@ -322,7 +322,7 @@ void* GetRemoteModuleEntryPoint(HANDLE hProcess, HMODULE hMod)
 
 HMODULE GetRemoteModuleHandle(HANDLE hProcess, const char *search_module)
 {
-	if condition_unlikely(!search_module) {
+	if UNEXPECTED(!search_module) {
 		return NULL;
 	}
 
@@ -363,22 +363,22 @@ FARPROC GetRemoteProcAddress(HANDLE hProcess, HMODULE hMod, LPCSTR lpProcName)
 {
 	BYTE *addr = (BYTE*)hMod;
 
-	if condition_unlikely(!lpProcName) {
+	if UNEXPECTED(!lpProcName) {
 		return NULL;
 	}
 
 	IMAGE_NT_HEADERS NTH;
-	if condition_unlikely(GetRemoteModuleNtHeader(&NTH, hProcess, hMod)) {
+	if UNEXPECTED(GetRemoteModuleNtHeader(&NTH, hProcess, hMod)) {
 		return NULL;
 	}
-	if condition_unlikely(NTH.OptionalHeader.NumberOfRvaAndSizes < IMAGE_DIRECTORY_ENTRY_EXPORT + 1) {
+	if UNEXPECTED(NTH.OptionalHeader.NumberOfRvaAndSizes < IMAGE_DIRECTORY_ENTRY_EXPORT + 1) {
 		return NULL;
 	}
 
 	PIMAGE_DATA_DIRECTORY pExportPos = &NTH.OptionalHeader.DataDirectory[IMAGE_DIRECTORY_ENTRY_EXPORT];
 
 	IMAGE_EXPORT_DIRECTORY ExportDesc;
-	if condition_unlikely(!ReadProcessMemory(hProcess, addr + pExportPos->VirtualAddress, &ExportDesc, sizeof(ExportDesc), NULL)) {
+	if UNEXPECTED(!ReadProcessMemory(hProcess, addr + pExportPos->VirtualAddress, &ExportDesc, sizeof(ExportDesc), NULL)) {
 		return NULL;
 	}
 
@@ -390,7 +390,7 @@ FARPROC GetRemoteProcAddress(HANDLE hProcess, HMODULE hMod, LPCSTR lpProcName)
 	size_t name_indices_size = ExportDesc.NumberOfNames * sizeof(WORD);
 
 	uint8_t* buffer = (uint8_t*)malloc(func_ptrs_size + name_ptrs_size + name_indices_size);
-	if condition_unlikely(!buffer) {
+	if UNEXPECTED(!buffer) {
 		return NULL;
 	}
 

--- a/thcrap/src/plugin.cpp
+++ b/thcrap/src/plugin.cpp
@@ -337,7 +337,7 @@ void plugin_load(const char *const fn_abs, const char *fn) {
 		return;
 	}
 #else
-	if unexpected(is_debug_plugin) {
+	if condition_unlikely(is_debug_plugin) {
 		log_printf("[Plugin] %s: debug plugin ignored in release mode\n", fn);
 		return;
 	}

--- a/thcrap/src/plugin.cpp
+++ b/thcrap/src/plugin.cpp
@@ -337,7 +337,7 @@ void plugin_load(const char *const fn_abs, const char *fn) {
 		return;
 	}
 #else
-	if condition_unlikely(is_debug_plugin) {
+	if UNEXPECTED(is_debug_plugin) {
 		log_printf("[Plugin] %s: debug plugin ignored in release mode\n", fn);
 		return;
 	}

--- a/thcrap/src/repo.cpp
+++ b/thcrap/src/repo.cpp
@@ -23,7 +23,7 @@ repo_t *RepoLoadJson(json_t *repo_js)
 	}
 
 	char* id = json_object_get_string_copy(repo_js, "id");
-	if unexpected(!id) {
+	if condition_unlikely(!id) {
 		return nullptr;
 	}
 	repo_t *repo = (repo_t*)malloc(sizeof(repo_t));

--- a/thcrap/src/repo.cpp
+++ b/thcrap/src/repo.cpp
@@ -23,7 +23,7 @@ repo_t *RepoLoadJson(json_t *repo_js)
 	}
 
 	char* id = json_object_get_string_copy(repo_js, "id");
-	if condition_unlikely(!id) {
+	if UNEXPECTED(!id) {
 		return nullptr;
 	}
 	repo_t *repo = (repo_t*)malloc(sizeof(repo_t));

--- a/thcrap/src/stack.cpp
+++ b/thcrap/src/stack.cpp
@@ -17,7 +17,7 @@ static std::vector<patch_t> stack;
 TH_CALLER_CLEANUP(chain_free)
 static char **resolve_chain_default(const char *fn)
 {
-	if unexpected(!fn) {
+	if condition_unlikely(!fn) {
 		return nullptr;
 	}
 	char **chain = (char**)malloc(sizeof(char*[3]));
@@ -98,7 +98,7 @@ bool TH_FASTCALL stack_chain_iterate(stack_chain_iterate_t *sci, char **chain, s
 		#define is_reverse (bool)(direction < 0)
 		{
 			const size_t stack_size = stack.size();
-			if unexpected(!stack_size) {
+			if condition_unlikely(!stack_size) {
 				// Failsafe for when there are no patches
 				return false;
 			}

--- a/thcrap/src/stack.cpp
+++ b/thcrap/src/stack.cpp
@@ -17,7 +17,7 @@ static std::vector<patch_t> stack;
 TH_CALLER_CLEANUP(chain_free)
 static char **resolve_chain_default(const char *fn)
 {
-	if condition_unlikely(!fn) {
+	if UNEXPECTED(!fn) {
 		return nullptr;
 	}
 	char **chain = (char**)malloc(sizeof(char*[3]));
@@ -98,7 +98,7 @@ bool TH_FASTCALL stack_chain_iterate(stack_chain_iterate_t *sci, char **chain, s
 		#define is_reverse (bool)(direction < 0)
 		{
 			const size_t stack_size = stack.size();
-			if condition_unlikely(!stack_size) {
+			if UNEXPECTED(!stack_size) {
 				// Failsafe for when there are no patches
 				return false;
 			}

--- a/thcrap/src/util.h
+++ b/thcrap/src/util.h
@@ -38,7 +38,7 @@ readable is to invert the condition, make the first branch an empty statement, a
 the intended statements in an else block. However, this still looks extremely weird and
 confusing, so this macro exists to better document the intent.
 */
-#define unexpected(condition) (!(condition)) TH_LIKELY; else TH_UNLIKELY
+#define condition_unlikely(condition) (!(condition)) TH_LIKELY; else TH_UNLIKELY
 
 #define func_ptr_typedef(return_type, calling_convention, name) \
 typedef return_type (calling_convention* name)

--- a/thcrap/src/util.h
+++ b/thcrap/src/util.h
@@ -38,7 +38,7 @@ readable is to invert the condition, make the first branch an empty statement, a
 the intended statements in an else block. However, this still looks extremely weird and
 confusing, so this macro exists to better document the intent.
 */
-#define condition_unlikely(condition) (!(condition)) TH_LIKELY; else TH_UNLIKELY
+#define UNEXPECTED(condition) (!(condition)) TH_LIKELY; else TH_UNLIKELY
 
 #define func_ptr_typedef(return_type, calling_convention, name) \
 typedef return_type (calling_convention* name)

--- a/thcrap/src/vfs.cpp
+++ b/thcrap/src/vfs.cpp
@@ -107,7 +107,7 @@ json_t *jsonvfs_get(const char* fn, size_t* size)
 
 static json_t *json_map_resolve(json_t *obj, const char *path)
 {
-	if unexpected(!path) {
+	if condition_unlikely(!path) {
 		return NULL;
 	}
 	for (const char* cur_start = path;; ++path) {

--- a/thcrap/src/vfs.cpp
+++ b/thcrap/src/vfs.cpp
@@ -107,7 +107,7 @@ json_t *jsonvfs_get(const char* fn, size_t* size)
 
 static json_t *json_map_resolve(json_t *obj, const char *path)
 {
-	if condition_unlikely(!path) {
+	if UNEXPECTED(!path) {
 		return NULL;
 	}
 	for (const char* cur_start = path;; ++path) {

--- a/thcrap/src/xpcompat.cpp
+++ b/thcrap/src/xpcompat.cpp
@@ -86,7 +86,7 @@ HRESULT STDAPICALLTYPE PathMatchSpecExU_xp(LPCSTR pszFile, LPCSTR pszSpec, DWORD
 
 static void initialize_path_match_spec_ex() {
 	HMODULE shlwapi_module = GetModuleHandleW(L"shlwapi.dll");
-	if unexpected(!shlwapi_module) {
+	if condition_unlikely(!shlwapi_module) {
 		shlwapi_module = LoadLibraryW(L"shlwapi.dll");
 	}
 	if (void* func_ex_w = (void*)GetProcAddress(shlwapi_module, "PathMatchSpecExW")) {

--- a/thcrap/src/xpcompat.cpp
+++ b/thcrap/src/xpcompat.cpp
@@ -86,7 +86,7 @@ HRESULT STDAPICALLTYPE PathMatchSpecExU_xp(LPCSTR pszFile, LPCSTR pszSpec, DWORD
 
 static void initialize_path_match_spec_ex() {
 	HMODULE shlwapi_module = GetModuleHandleW(L"shlwapi.dll");
-	if condition_unlikely(!shlwapi_module) {
+	if UNEXPECTED(!shlwapi_module) {
 		shlwapi_module = LoadLibraryW(L"shlwapi.dll");
 	}
 	if (void* func_ex_w = (void*)GetProcAddress(shlwapi_module, "PathMatchSpecExW")) {

--- a/thcrap_loader/src/loader.cpp
+++ b/thcrap_loader/src/loader.cpp
@@ -280,7 +280,7 @@ int TH_CDECL win32_utf8_main(int argc, const char *argv[])
 			goto end;
 		case ALT_ARCH_BITS: {
 #if !TH_X64
-			if unexpected(!OS_is_wow64()) {
+			if UNEXPECTED(!OS_is_wow64()) {
 				log_mboxf(NULL, MB_OK | MB_ICONEXCLAMATION,
 					"Cannot run a 64 bit executable on a 32 bit OS.\n"
 					"\"%s\"\n"
@@ -304,7 +304,7 @@ int TH_CDECL win32_utf8_main(int argc, const char *argv[])
 			PROCESS_INFORMATION pi = {};
 			BOOL success = CreateProcessW(L"bin/thcrap_loader" ALT_FILE_SUFFIX_W L".exe", new_args, NULL, NULL, FALSE, 0, NULL, NULL, &si, &pi);
 			VLA_FREE(new_args);
-			if unexpected(!success) {
+			if UNEXPECTED(!success) {
 				ret = -5;
 				goto end;
 			}

--- a/thcrap_tasofro/src/tasofro_file.cpp
+++ b/thcrap_tasofro/src/tasofro_file.cpp
@@ -74,7 +74,7 @@ bool TasofroFile::need_replace() const
 {
 	// If dat_dump is enabled, we always want to run the patching code
 	// so that we can dump the files in it
-	if unexpected(runconfig_dat_dump_get()) {
+	if condition_unlikely(runconfig_dat_dump_get()) {
 		return true;
 	}
 
@@ -125,7 +125,7 @@ void TasofroFile::replace_ReadFile_init(ReadFileStack *stack,
 	// Return true if we need to read the original file, false otherwise.
 	auto need_orig_file = [=]() {
 		// If dat_dump is enabled, we *always* need the original buffer
-		if unexpected(dat_dump) {
+		if condition_unlikely(dat_dump) {
 			return true;
 		}
 		// We have a replacement file, no need to read the original one (even if we have
@@ -152,7 +152,7 @@ void TasofroFile::replace_ReadFile_init(ReadFileStack *stack,
 
 		decrypt(this, (BYTE*)game_buffer, pre_json_size);
 
-		if unexpected(dat_dump) {
+		if condition_unlikely(dat_dump) {
 			DumpDatFile(dat_dump, this->name, game_buffer, pre_json_size, false);
 		}
 		// If there are hooks and no replacement file
@@ -209,7 +209,7 @@ int TasofroFile::replace_ReadFile(x86_reg_t *regs,
 {
 	ReadFileStack *stack = (ReadFileStack*)(regs->esp + sizeof(void*));
 
-	if unexpected(stack->lpOverlapped) {
+	if condition_unlikely(stack->lpOverlapped) {
 		// Overlapped operations are not supported.
 		// We'd better leave that file alone rather than ignoring that.
 		return 1;
@@ -219,7 +219,7 @@ int TasofroFile::replace_ReadFile(x86_reg_t *regs,
 		this->replace_ReadFile_init(stack, decrypt, crypt);
 	}
 
-	if unexpected(this->rep_buffer) {
+	if condition_unlikely(this->rep_buffer) {
 		return this->replace_ReadFile_write(regs, stack);
 	}
 	return 1;

--- a/thcrap_tasofro/src/tasofro_file.cpp
+++ b/thcrap_tasofro/src/tasofro_file.cpp
@@ -74,7 +74,7 @@ bool TasofroFile::need_replace() const
 {
 	// If dat_dump is enabled, we always want to run the patching code
 	// so that we can dump the files in it
-	if condition_unlikely(runconfig_dat_dump_get()) {
+	if UNEXPECTED(runconfig_dat_dump_get()) {
 		return true;
 	}
 
@@ -125,7 +125,7 @@ void TasofroFile::replace_ReadFile_init(ReadFileStack *stack,
 	// Return true if we need to read the original file, false otherwise.
 	auto need_orig_file = [=]() {
 		// If dat_dump is enabled, we *always* need the original buffer
-		if condition_unlikely(dat_dump) {
+		if UNEXPECTED(dat_dump) {
 			return true;
 		}
 		// We have a replacement file, no need to read the original one (even if we have
@@ -152,7 +152,7 @@ void TasofroFile::replace_ReadFile_init(ReadFileStack *stack,
 
 		decrypt(this, (BYTE*)game_buffer, pre_json_size);
 
-		if condition_unlikely(dat_dump) {
+		if UNEXPECTED(dat_dump) {
 			DumpDatFile(dat_dump, this->name, game_buffer, pre_json_size, false);
 		}
 		// If there are hooks and no replacement file
@@ -209,7 +209,7 @@ int TasofroFile::replace_ReadFile(x86_reg_t *regs,
 {
 	ReadFileStack *stack = (ReadFileStack*)(regs->esp + sizeof(void*));
 
-	if condition_unlikely(stack->lpOverlapped) {
+	if UNEXPECTED(stack->lpOverlapped) {
 		// Overlapped operations are not supported.
 		// We'd better leave that file alone rather than ignoring that.
 		return 1;
@@ -219,7 +219,7 @@ int TasofroFile::replace_ReadFile(x86_reg_t *regs,
 		this->replace_ReadFile_init(stack, decrypt, crypt);
 	}
 
-	if condition_unlikely(this->rep_buffer) {
+	if UNEXPECTED(this->rep_buffer) {
 		return this->replace_ReadFile_write(regs, stack);
 	}
 	return 1;

--- a/thcrap_tasofro/src/th135.cpp
+++ b/thcrap_tasofro/src/th135.cpp
@@ -82,7 +82,7 @@ int th135_init()
 
 extern "C" size_t BP_th135_file_name(x86_reg_t *regs, json_t *bp_info)
 {
-	if unexpected(runconfig_dat_dump_get()) {
+	if condition_unlikely(runconfig_dat_dump_get()) {
 		if (const char *filename = (const char*)json_object_get_immediate(bp_info, regs, "file_name")) {
 			register_filename(filename);
 		}
@@ -186,7 +186,7 @@ bool th135_init_fr(Th135File *fr, std::filesystem::path& path)
 		// This write is safe because the string length is known and doesn't change
 		*(uint32_t*)&path_ptr[final_dot + 1] = TextInt('p', 'n', 'g', '\0');
 
-		if unexpected(runconfig_dat_dump_get()) {
+		if condition_unlikely(runconfig_dat_dump_get()) {
 			register_utf8_filename(path_ptr);
 		}
 
@@ -210,7 +210,7 @@ template<typename T>
 size_t th135_openFileCommon(const char *filename, T *file)
 {
 #if AoCF_PROFILING
-	if unexpected(!file_count++) {
+	if condition_unlikely(!file_count++) {
 		QueryPerformanceCounter(&qpc_start);
 	}
 #endif
@@ -278,7 +278,7 @@ extern "C" size_t BP_th135_replaceReadFile(x86_reg_t *regs, json_t*)
 		// exactly 610 files before reaching the main menu,
 		// so this can be used to roughly measure how much
 		// time is getting used just by the file replacement code.
-		if unexpected(file_count == 610) {
+		if condition_unlikely(file_count == 610) {
 			LARGE_INTEGER qpc_end;
 			QueryPerformanceCounter(&qpc_end);
 			LARGE_INTEGER perf_freq;

--- a/thcrap_tasofro/src/th135.cpp
+++ b/thcrap_tasofro/src/th135.cpp
@@ -82,7 +82,7 @@ int th135_init()
 
 extern "C" size_t BP_th135_file_name(x86_reg_t *regs, json_t *bp_info)
 {
-	if condition_unlikely(runconfig_dat_dump_get()) {
+	if UNEXPECTED(runconfig_dat_dump_get()) {
 		if (const char *filename = (const char*)json_object_get_immediate(bp_info, regs, "file_name")) {
 			register_filename(filename);
 		}
@@ -186,7 +186,7 @@ bool th135_init_fr(Th135File *fr, std::filesystem::path& path)
 		// This write is safe because the string length is known and doesn't change
 		*(uint32_t*)&path_ptr[final_dot + 1] = TextInt('p', 'n', 'g', '\0');
 
-		if condition_unlikely(runconfig_dat_dump_get()) {
+		if UNEXPECTED(runconfig_dat_dump_get()) {
 			register_utf8_filename(path_ptr);
 		}
 
@@ -210,7 +210,7 @@ template<typename T>
 size_t th135_openFileCommon(const char *filename, T *file)
 {
 #if AoCF_PROFILING
-	if condition_unlikely(!file_count++) {
+	if UNEXPECTED(!file_count++) {
 		QueryPerformanceCounter(&qpc_start);
 	}
 #endif
@@ -278,7 +278,7 @@ extern "C" size_t BP_th135_replaceReadFile(x86_reg_t *regs, json_t*)
 		// exactly 610 files before reaching the main menu,
 		// so this can be used to roughly measure how much
 		// time is getting used just by the file replacement code.
-		if condition_unlikely(file_count == 610) {
+		if UNEXPECTED(file_count == 610) {
 			LARGE_INTEGER qpc_end;
 			QueryPerformanceCounter(&qpc_end);
 			LARGE_INTEGER perf_freq;

--- a/thcrap_tasofro/src/th155_bmp_font.cpp
+++ b/thcrap_tasofro/src/th155_bmp_font.cpp
@@ -140,17 +140,17 @@ void fill_chars_list_from_font(char *TH_RESTRICT chars_list, const void *file_in
 	};
 	static_assert(sizeof(Metadata) == 4);
 
-	if unexpected(size_in < sizeof(BITMAPFILEHEADER)) {
+	if condition_unlikely(size_in < sizeof(BITMAPFILEHEADER)) {
 		return ;
 	}
 	const BITMAPFILEHEADER *bpFile = (const BITMAPFILEHEADER*)file_inout;
 
-	if unexpected(size_in < bpFile->bfSize + sizeof(Metadata)) {
+	if condition_unlikely(size_in < bpFile->bfSize + sizeof(Metadata)) {
 		return ;
 	}
 	const Metadata *metadata = (const Metadata*)((const BYTE*)file_inout + bpFile->bfSize);
 
-	if unexpected(size_in < bpFile->bfSize + sizeof(Metadata) + (metadata->nb_chars * 2)) {
+	if condition_unlikely(size_in < bpFile->bfSize + sizeof(Metadata) + (metadata->nb_chars * 2)) {
 		return ;
 	}
 
@@ -189,7 +189,7 @@ void TH_CDECL fill_chars_list_from_all_files_impl(const patch_t* patch, void*) {
 }
 
 void fill_chars_list_from_all_files(char *TH_RESTRICT chars_list) {
-	if unexpected(!all_files_list_initialized) {
+	if condition_unlikely(!all_files_list_initialized) {
 		log_print("(Font) Searching in every js file for characters...\n");
 		stack_foreach(fill_chars_list_from_all_files_impl, NULL);
 		all_files_list_initialized = true;
@@ -321,7 +321,7 @@ BYTE *read_bmpfont_from_cache(const char* fn, char *TH_RESTRICT chars_list, size
 					B = _mm_slli_epi16(B, 3);
 					B = _mm_add_epi8(B, A);
 					B = _mm_add_epi8(B, text_conv);
-					if unexpected(_mm_movemask_epi8(_mm_cmpeq_epi8(_mm_loadu_si128((__m128i*)(cached_chars_list + i)), B)) != 0xFFFF) {
+					if condition_unlikely(_mm_movemask_epi8(_mm_cmpeq_epi8(_mm_loadu_si128((__m128i*)(cached_chars_list + i)), B)) != 0xFFFF) {
 						goto fail;
 					}
 				}
@@ -361,7 +361,7 @@ int bmpfont_add_option_color(void *bmpfont, const char *name, json_t *value)
 
 bool generate_bitmap_font(void *bmpfont, char *TH_RESTRICT chars_list, json_t *patch, BYTE **buffer, size_t *buffer_size)
 {
-	if unexpected(bmpfont == nullptr) {
+	if condition_unlikely(bmpfont == nullptr) {
 		return false;
 	}
 
@@ -374,7 +374,7 @@ bool generate_bitmap_font(void *bmpfont, char *TH_RESTRICT chars_list, json_t *p
 	// Plugin
 	const char *thcrap_dir = runconfig_thcrap_dir_get();
 	const char *plugin     = json_object_get_string(patch, "plugin");
-	if unexpected(plugin == nullptr) {
+	if condition_unlikely(plugin == nullptr) {
 		log_print("[Bmpfont] Jdiff file must have a 'plugin' entry\n");
 		return false;
 	}
@@ -429,7 +429,7 @@ bool generate_bitmap_font(void *bmpfont, char *TH_RESTRICT chars_list, json_t *p
 	ret &= bmpfont_add_option_binary(bmpfont, "--out-size", buffer_size, sizeof(size_t));
 	ret &= bmpfont_add_option_binary(bmpfont, "--chars-list", chars_list, sizeof(char[MAX_CHARS]));
 
-	if unexpected(!ret) {
+	if condition_unlikely(!ret) {
 		return false;
 	}
 
@@ -469,12 +469,12 @@ int patch_bmp_font(void *file_inout, size_t size_out, size_t size_in, const char
 			}
 		}
 		free(chars_list);
-		if unexpected(!buffer) {
+		if condition_unlikely(!buffer) {
 			log_print("Bitmap font creation failed\n");
 			bmpfont_free(bmpfont);
 			return -1;
 		}
-		if unexpected(buffer_size > size_out) {
+		if condition_unlikely(buffer_size > size_out) {
 			log_print("Bitmap font too big\n");
 			if (bmpfont) {
 				bmpfont_free(bmpfont);
@@ -507,7 +507,7 @@ int patch_bmp_font(void *file_inout, size_t size_out, size_t size_in, const char
 	BYTE** row_pointers = png_image_read(fn_buf, &width, &height, &bpp, false);
 
 	if (row_pointers) {
-		if unexpected(!row_pointers || size_out < sizeof(BITMAPFILEHEADER) + sizeof(BITMAPINFOHEADER) + width * height) {
+		if condition_unlikely(!row_pointers || size_out < sizeof(BITMAPFILEHEADER) + sizeof(BITMAPINFOHEADER) + width * height) {
 			VLA_FREE(fn_buf);
 			log_print("Destination buffer too small!\n");
 			free(row_pointers);
@@ -547,7 +547,7 @@ int patch_bmp_font(void *file_inout, size_t size_out, size_t size_in, const char
 	VLA_FREE(fn_buf);
 
 	if (bin_data) {
-		if unexpected(size_out < sizeof(BITMAPFILEHEADER) + sizeof(BITMAPINFOHEADER) + bpInfo->biWidth * 4 * bpInfo->biHeight + bin_size) {
+		if condition_unlikely(size_out < sizeof(BITMAPFILEHEADER) + sizeof(BITMAPINFOHEADER) + bpInfo->biWidth * 4 * bpInfo->biHeight + bin_size) {
 			log_print("Destination buffer too small!\n");
 			free(bin_data);
 			return -1;

--- a/thcrap_tasofro/src/th155_bmp_font.cpp
+++ b/thcrap_tasofro/src/th155_bmp_font.cpp
@@ -140,17 +140,17 @@ void fill_chars_list_from_font(char *TH_RESTRICT chars_list, const void *file_in
 	};
 	static_assert(sizeof(Metadata) == 4);
 
-	if condition_unlikely(size_in < sizeof(BITMAPFILEHEADER)) {
+	if UNEXPECTED(size_in < sizeof(BITMAPFILEHEADER)) {
 		return ;
 	}
 	const BITMAPFILEHEADER *bpFile = (const BITMAPFILEHEADER*)file_inout;
 
-	if condition_unlikely(size_in < bpFile->bfSize + sizeof(Metadata)) {
+	if UNEXPECTED(size_in < bpFile->bfSize + sizeof(Metadata)) {
 		return ;
 	}
 	const Metadata *metadata = (const Metadata*)((const BYTE*)file_inout + bpFile->bfSize);
 
-	if condition_unlikely(size_in < bpFile->bfSize + sizeof(Metadata) + (metadata->nb_chars * 2)) {
+	if UNEXPECTED(size_in < bpFile->bfSize + sizeof(Metadata) + (metadata->nb_chars * 2)) {
 		return ;
 	}
 
@@ -189,7 +189,7 @@ void TH_CDECL fill_chars_list_from_all_files_impl(const patch_t* patch, void*) {
 }
 
 void fill_chars_list_from_all_files(char *TH_RESTRICT chars_list) {
-	if condition_unlikely(!all_files_list_initialized) {
+	if UNEXPECTED(!all_files_list_initialized) {
 		log_print("(Font) Searching in every js file for characters...\n");
 		stack_foreach(fill_chars_list_from_all_files_impl, NULL);
 		all_files_list_initialized = true;
@@ -321,7 +321,7 @@ BYTE *read_bmpfont_from_cache(const char* fn, char *TH_RESTRICT chars_list, size
 					B = _mm_slli_epi16(B, 3);
 					B = _mm_add_epi8(B, A);
 					B = _mm_add_epi8(B, text_conv);
-					if condition_unlikely(_mm_movemask_epi8(_mm_cmpeq_epi8(_mm_loadu_si128((__m128i*)(cached_chars_list + i)), B)) != 0xFFFF) {
+					if UNEXPECTED(_mm_movemask_epi8(_mm_cmpeq_epi8(_mm_loadu_si128((__m128i*)(cached_chars_list + i)), B)) != 0xFFFF) {
 						goto fail;
 					}
 				}
@@ -361,7 +361,7 @@ int bmpfont_add_option_color(void *bmpfont, const char *name, json_t *value)
 
 bool generate_bitmap_font(void *bmpfont, char *TH_RESTRICT chars_list, json_t *patch, BYTE **buffer, size_t *buffer_size)
 {
-	if condition_unlikely(bmpfont == nullptr) {
+	if UNEXPECTED(bmpfont == nullptr) {
 		return false;
 	}
 
@@ -374,7 +374,7 @@ bool generate_bitmap_font(void *bmpfont, char *TH_RESTRICT chars_list, json_t *p
 	// Plugin
 	const char *thcrap_dir = runconfig_thcrap_dir_get();
 	const char *plugin     = json_object_get_string(patch, "plugin");
-	if condition_unlikely(plugin == nullptr) {
+	if UNEXPECTED(plugin == nullptr) {
 		log_print("[Bmpfont] Jdiff file must have a 'plugin' entry\n");
 		return false;
 	}
@@ -429,7 +429,7 @@ bool generate_bitmap_font(void *bmpfont, char *TH_RESTRICT chars_list, json_t *p
 	ret &= bmpfont_add_option_binary(bmpfont, "--out-size", buffer_size, sizeof(size_t));
 	ret &= bmpfont_add_option_binary(bmpfont, "--chars-list", chars_list, sizeof(char[MAX_CHARS]));
 
-	if condition_unlikely(!ret) {
+	if UNEXPECTED(!ret) {
 		return false;
 	}
 
@@ -469,12 +469,12 @@ int patch_bmp_font(void *file_inout, size_t size_out, size_t size_in, const char
 			}
 		}
 		free(chars_list);
-		if condition_unlikely(!buffer) {
+		if UNEXPECTED(!buffer) {
 			log_print("Bitmap font creation failed\n");
 			bmpfont_free(bmpfont);
 			return -1;
 		}
-		if condition_unlikely(buffer_size > size_out) {
+		if UNEXPECTED(buffer_size > size_out) {
 			log_print("Bitmap font too big\n");
 			if (bmpfont) {
 				bmpfont_free(bmpfont);
@@ -507,7 +507,7 @@ int patch_bmp_font(void *file_inout, size_t size_out, size_t size_in, const char
 	BYTE** row_pointers = png_image_read(fn_buf, &width, &height, &bpp, false);
 
 	if (row_pointers) {
-		if condition_unlikely(!row_pointers || size_out < sizeof(BITMAPFILEHEADER) + sizeof(BITMAPINFOHEADER) + width * height) {
+		if UNEXPECTED(!row_pointers || size_out < sizeof(BITMAPFILEHEADER) + sizeof(BITMAPINFOHEADER) + width * height) {
 			VLA_FREE(fn_buf);
 			log_print("Destination buffer too small!\n");
 			free(row_pointers);
@@ -547,7 +547,7 @@ int patch_bmp_font(void *file_inout, size_t size_out, size_t size_in, const char
 	VLA_FREE(fn_buf);
 
 	if (bin_data) {
-		if condition_unlikely(size_out < sizeof(BITMAPFILEHEADER) + sizeof(BITMAPINFOHEADER) + bpInfo->biWidth * 4 * bpInfo->biHeight + bin_size) {
+		if UNEXPECTED(size_out < sizeof(BITMAPFILEHEADER) + sizeof(BITMAPINFOHEADER) + bpInfo->biWidth * 4 * bpInfo->biHeight + bin_size) {
 			log_print("Destination buffer too small!\n");
 			free(bin_data);
 			return -1;

--- a/thcrap_tasofro/src/th175_pl_ed.cpp
+++ b/thcrap_tasofro/src/th175_pl_ed.cpp
@@ -132,7 +132,7 @@ bool is_msg_empty(const std::vector<std::string>& msg)
 
 int patch_th175_pl_ed(void *file_inout, size_t, size_t size_in, const char *, json_t *patch)
 {
-	if unexpected(!patch) {
+	if condition_unlikely(!patch) {
 		return 0;
 	}
 

--- a/thcrap_tasofro/src/th175_pl_ed.cpp
+++ b/thcrap_tasofro/src/th175_pl_ed.cpp
@@ -132,7 +132,7 @@ bool is_msg_empty(const std::vector<std::string>& msg)
 
 int patch_th175_pl_ed(void *file_inout, size_t, size_t size_in, const char *, json_t *patch)
 {
-	if condition_unlikely(!patch) {
+	if UNEXPECTED(!patch) {
 		return 0;
 	}
 

--- a/thcrap_tsa/src/layout.cpp
+++ b/thcrap_tsa/src/layout.cpp
@@ -608,7 +608,7 @@ void ruby_shift_debug_impl(HDC hdc, int orig_x) {
 
 
 void debug_colorfill_impl(HDC hdc) {
-	if unexpected(debug_fill_brush) {
+	if condition_unlikely(debug_fill_brush) {
 		RECT drawRect = { 0, 0, GetDeviceCaps(hdc, HORZRES), GetDeviceCaps(hdc, VERTRES) };
 		FillRect(hdc, &drawRect, debug_fill_brush);
 	}
@@ -812,7 +812,7 @@ int layout_mod_init(HMODULE hMod)
 	(void)json_object_get_eval_bool(runcfg, "ruby_shift_debug", &ruby_shift_debug, JEVAL_DEFAULT);
 
 	size_t col;
-	if unexpected(!json_object_get_eval_int(runcfg, "hdc_debug_color", &col, JEVAL_DEFAULT)) {
+	if condition_unlikely(!json_object_get_eval_int(runcfg, "hdc_debug_color", &col, JEVAL_DEFAULT)) {
 		// Truncation to the lower 32 bits in 64 bit mode
 		debug_fill_brush = CreateSolidBrush((COLORREF)col);
 	}

--- a/thcrap_tsa/src/layout.cpp
+++ b/thcrap_tsa/src/layout.cpp
@@ -608,7 +608,7 @@ void ruby_shift_debug_impl(HDC hdc, int orig_x) {
 
 
 void debug_colorfill_impl(HDC hdc) {
-	if condition_unlikely(debug_fill_brush) {
+	if UNEXPECTED(debug_fill_brush) {
 		RECT drawRect = { 0, 0, GetDeviceCaps(hdc, HORZRES), GetDeviceCaps(hdc, VERTRES) };
 		FillRect(hdc, &drawRect, debug_fill_brush);
 	}
@@ -812,7 +812,7 @@ int layout_mod_init(HMODULE hMod)
 	(void)json_object_get_eval_bool(runcfg, "ruby_shift_debug", &ruby_shift_debug, JEVAL_DEFAULT);
 
 	size_t col;
-	if condition_unlikely(!json_object_get_eval_int(runcfg, "hdc_debug_color", &col, JEVAL_DEFAULT)) {
+	if UNEXPECTED(!json_object_get_eval_int(runcfg, "hdc_debug_color", &col, JEVAL_DEFAULT)) {
 		// Truncation to the lower 32 bits in 64 bit mode
 		debug_fill_brush = CreateSolidBrush((COLORREF)col);
 	}

--- a/thcrap_update/src/file.cpp
+++ b/thcrap_update/src/file.cpp
@@ -12,7 +12,7 @@ File::File(std::list<DownloadUrl>&& urls,
     : status(Status::Todo), urls(urls),
     userSuccessCallback(successCallback), userFailureCallback(failureCallback), userProgressCallback(progressCallback)
 {
-    if unexpected(urls.empty()) {
+    if condition_unlikely(urls.empty()) {
         throw new std::invalid_argument("Input URL list must not be empty");
     }
 }

--- a/thcrap_update/src/file.cpp
+++ b/thcrap_update/src/file.cpp
@@ -12,7 +12,7 @@ File::File(std::list<DownloadUrl>&& urls,
     : status(Status::Todo), urls(urls),
     userSuccessCallback(successCallback), userFailureCallback(failureCallback), userProgressCallback(progressCallback)
 {
-    if condition_unlikely(urls.empty()) {
+    if UNEXPECTED(urls.empty()) {
         throw new std::invalid_argument("Input URL list must not be empty");
     }
 }

--- a/thcrap_update/src/self.cpp
+++ b/thcrap_update/src/self.cpp
@@ -273,7 +273,7 @@ static int self_pubkey_from_signer(PCCERT_CONTEXT* context)
 	DWORD param_len;
 	DWORD signer_num;
 
-	if unexpected(!context || !self_mod) {
+	if condition_unlikely(!context || !self_mod) {
 		return -1;
 	}
 	{

--- a/thcrap_update/src/self.cpp
+++ b/thcrap_update/src/self.cpp
@@ -273,7 +273,7 @@ static int self_pubkey_from_signer(PCCERT_CONTEXT* context)
 	DWORD param_len;
 	DWORD signer_num;
 
-	if condition_unlikely(!context || !self_mod) {
+	if UNEXPECTED(!context || !self_mod) {
 		return -1;
 	}
 	{


### PR DESCRIPTION
This PR renames the `unexpected` macro to ~~`condition_unlikely`~~ `UNEXPECTED`. Because C++23 reintroduces the name `std::unexpected<E>`, this change is needed to remove the possibility of clashing with the standard on later versions. ~~`condition_unlikely` seems like a more reasonable name, because rather than implying that it should never be expected, it indicates what the hot paths (`[[likely]]`/`[[unlikely]]` attributes) are.~~ The rename to `UNEXPECTED` is consistent with other macros which are `ALL_CAPS`; although `TH_UNEXPECTED` was considered, this was dropped. 

`CXXFLAGS += -D_GLIBCXX_USE_DEPRECATED=0` was done originally to eliminate the deprecated `std::unexpected()` (deprecated in C++11 and removed in C++17). Because the macro has been renamed, this is no longer needed.

It was pointed out that the codebase cannot move forward to C++23 (until dropping support for Windows XP or changing the build system). At the very least, this change serves as future-proofing and allows the Makefile to be simplified by dropping the disabled `GLIBCXX_USE_DEPRECATED` option.